### PR TITLE
feat(recall): recent_sessions + human timestamps; English docs; fix plugin tool namespacing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ node_modules/
 
 # SDD scratch ledger
 .superpowers/
+maxim/

--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
 # session-recall
 
 Local, agentic **semantic recall over your Claude Code session history**. It gives the
-agent four tools (via MCP) so it can resume past work instead of making you re-explain it:
+agent five tools (via MCP) so it can resume past work instead of making you re-explain it:
 
 - `recall_search(query)` — find a past discussion **by meaning** (not substring).
 - `expand_around(session_id, uuid)` — a cursor into the raw turn (tool calls, outputs, thinking).
 - `step(session_id, uuid, direction)` — move to an adjacent turn (cheap cursor step).
 - `grep(pattern)` — on-demand substring scan over the raw transcripts.
+- `recent_sessions()` — the freshest past sessions first (what's current, how fresh the index is).
 
 On-demand (no proactive auto-injection in v1). Local, open source.
 
-`recall_search` and `grep` also take an optional `scope_cwd` — pass your current working
-directory to scope results to the current repo (worktrees collapse to the repo root);
-omit it for cross-project recall.
+`recall_search`, `grep` and `recent_sessions` also take an optional `scope_cwd` — pass your
+current working directory to scope results to the current repo (worktrees collapse to the repo
+root); omit it for cross-project recall. Ranked hits carry a human-readable `when_human`
+timestamp alongside the raw epoch.
 
 **Status:** v1, built and validated on real history. Key design rationale lives in
 [docs/decisions/](docs/decisions/).

--- a/agents/recall.md
+++ b/agents/recall.md
@@ -2,7 +2,7 @@
 name: recall
 description: Use to get instantly grounded in a task, bug, feature, or decision that may have been worked on in a PREVIOUS Claude Code session. Dispatch with the topic; it searches the session history deeply (semantic + keyword + drill-down), reads the raw turns itself, and returns ONLY a tight brief — keeping the main thread's context clean. Prefer over calling recall_search directly when you need the full arc of a past task, not just a snippet.
 model: sonnet
-tools: mcp__session-recall__recall_search, mcp__session-recall__expand_around, mcp__session-recall__step, mcp__session-recall__grep, Read
+tools: mcp__plugin_session-recall_session-recall__recall_search, mcp__plugin_session-recall_session-recall__expand_around, mcp__plugin_session-recall_session-recall__step, mcp__plugin_session-recall_session-recall__grep, mcp__plugin_session-recall_session-recall__recent_sessions, mcp__session-recall__recall_search, mcp__session-recall__expand_around, mcp__session-recall__step, mcp__session-recall__grep, mcp__session-recall__recent_sessions, Read
 ---
 
 You are a session-history retrieval specialist. Given a task/topic, dig through the user's
@@ -10,6 +10,10 @@ past Claude Code sessions and return a tight, decision-focused brief — nothing
 YOUR context on the raw retrieval so the main thread stays clean.
 
 ## How to search (be thorough — it is cheap for you)
+Ground the brief in these recall tools over the raw transcripts — that is the point; do not
+reconstruct from git logs or memory files when the recall tools can answer.
+0. If the topic is "what's the latest / current state", `recent_sessions(scope_cwd=<cwd>)` lists
+   the freshest sessions first (turn counts + first-prompt labels) to orient before drilling in.
 1. `recall_search(<topic>)` — semantic search. Try 2-3 phrasings if the first is thin; the
    user re-describes tasks loosely. If your dispatch names a current working directory / project,
    pass it as `scope_cwd` (works on `grep` too) to scope results to that repo — worktrees collapse

--- a/docs/decisions/2026-06-25-extract-noise-and-dedup.md
+++ b/docs/decisions/2026-06-25-extract-noise-and-dedup.md
@@ -1,76 +1,76 @@
-# Чистка harness-мусора на extract-time + дедуп на retrieve-time
+# Strip harness noise at extract-time + dedup at retrieve-time
 
-**Дата:** 2026-06-25 · **Ветка:** `fix/extract-noise-dedup`
+**Date:** 2026-06-25 · **Branch:** `fix/extract-noise-dedup`
 
-## Контекст
+## Context
 
-Валидация поиска на 30 независимых баг-кейсах (намайнены Codex'ом из реальной
-истории, запросы перефразированы без ключевых слов) дала sessionHit@10 = 24/30 —
-рабочий semantic-recall, — но вскрыла два дефекта качества:
+Search validation on 30 independent bug cases (mined by Codex from real
+history, queries paraphrased without keywords) gave sessionHit@10 = 24/30 — a
+working semantic recall — but exposed two quality defects:
 
-- **Баг A — harness-мусор как «речь юзера».** `extract.py` индексировал любой
-  строковый `user.content`. Но Claude Code инжектит в user-турны машинный текст:
+- **Bug A — harness noise treated as "user speech".** `extract.py` indexed any
+  string `user.content`. But Claude Code injects machine text into user turns:
   `<task-notification>`, `<system-reminder>`, `<command-message>`/`<command-name>`,
-  `<local-command-stdout>`, строки `Caveat:`. Замер: **1470 чанков = 4.6% индекса =
-  22.5% всех user-чанков.** В валидации эти блобы вставали #1 на реальные запросы
-  (security-вопрос вернул `<task-notification>` со скором 0.625), вытесняя суть.
-- **Баг B — дубликаты в выдаче.** `content_hash` считался, но для дедупа не
-  использовался; на retrieve нет diversity-шага. Замер: **4137 чанков (13%)** делят
-  `content_hash` с другим (resume-сессии / сайдчейны / повторы). В валидации два
-  идентичных чанка заняли слоты #1 и #2 (0.879 дважды).
+  `<local-command-stdout>`, `Caveat:` lines. Measurement: **1470 chunks = 4.6% of the index =
+  22.5% of all user chunks.** In validation these blobs ranked #1 on real queries
+  (a security question returned `<task-notification>` with score 0.625), crowding out the substance.
+- **Bug B — duplicates in results.** `content_hash` was computed but not
+  used for dedup; there is no diversity step at retrieve. Measurement: **4137 chunks (13%)** share a
+  `content_hash` with another (resume sessions / sidechains / repeats). In validation two
+  identical chunks took slots #1 and #2 (0.879 twice).
 
-Решение приняли советом Storm (4/4 движка — claude/codex/glm/gemini — ответили ok;
-выжимка `/tmp/storm-fix.json`).
+The decision was made by a Storm council (4/4 engines — claude/codex/glm/gemini — answered ok;
+digest `/tmp/storm-fix.json`).
 
-## Решение
+## Decision
 
-- **Баг A → extract-time, «strip-and-keep-residual».** Вырезаем ПОЛНЫЕ парные
-  блоки `<tag>…</tag>` из allowlist + строки-якоря `Caveat: The messages below…` /
-  `[Request interrupted…]`; если остаток пуст — турн выкидываем, иначе индексируем
-  остаток. `content_hash` считается по очищенному тексту, а `byte_offset/byte_len`
-  остаются на сырой строке (expand_around → источник).
-- **Баг B → retrieve-time коллапс по `content_hash` ДО реранка**, на полном пуле
-  кандидатов; все строки остаются в БД (provenance). Один представитель на хэш.
-- **Корень дублей → `index.py` delete-before-reinsert.** Перед переиндексом
-  изменённого файла зовём `store.delete_file(path)` — иначе растущий транскрипт
-  плодит дубли при каждом ре-скане. + `EXTRACTOR_VERSION` в сигнатуре файла: бамп
-  версии инвалидирует все файлы → чистый авто-реиндекс при будущих правках экстрактора.
-- **Миграция → полный re-index** (drop DB → `session-recall index`).
+- **Bug A → extract-time, "strip-and-keep-residual".** Cut out COMPLETE paired
+  `<tag>…</tag>` blocks from an allowlist + anchor lines `Caveat: The messages below…` /
+  `[Request interrupted…]`; if the residual is empty — drop the turn, otherwise index the
+  residual. `content_hash` is computed over the cleaned text, while `byte_offset/byte_len`
+  stay on the raw string (expand_around → source).
+- **Bug B → retrieve-time collapse by `content_hash` BEFORE rerank**, over the full
+  candidate pool; all rows stay in the DB (provenance). One representative per hash.
+- **Root cause of duplicates → `index.py` delete-before-reinsert.** Before reindexing
+  a changed file we call `store.delete_file(path)` — otherwise a growing transcript
+  spawns duplicates on every re-scan. + `EXTRACTOR_VERSION` in the file signature: bumping
+  the version invalidates all files → clean auto-reindex on future extractor changes.
+- **Migration → full re-index** (drop DB → `session-recall index`).
 
-## Почему
+## Why
 
-- **Extract-time, не retrieve-time (A):** реранк НЕ давит мусор (был #1 @0.625),
-  значит он не должен попадать в кандидаты вовсе; плюс не платим Voyage за эмбеддинг
-  мусора. Retrieve-time всё равно хранил/эмбедил/реранкал бы его.
-- **Парные теги, не `if "<tag>" in text`:** юзер, процитировавший `<system-reminder>`
-  без закрывающего тега, выживает (≈0 ложных срабатываний). `Caveat:` якорим на полное
-  harness-предложение, не на голое слово.
-- **Retrieve-дедуп, не index-skip (B):** один и тот же текст в разных сессиях
-  легитимен (контекст вокруг разный) — index-skip убил бы provenance.
-- **Без MMR сейчас:** измеренный баг — ТОЧНЫЕ дубли (один хэш), хэш-коллапс решает их
-  даром и без тюнинга; MMR (near-dup) добавляет λ-ручку и риск выкинуть релевантное —
-  отложено в v2 до доказательства необходимости.
-- **Full re-index, не in-place DELETE:** DELETE убирает только standalone-мусор, но не
-  чинит частично-boilerplate строки (их эмбеддинг посчитан по грязному тексту → дрейф
-  текст↔вектор); re-index без дрейфа, индекс одноразов по leak-proof инварианту, ~$1–3.
+- **Extract-time, not retrieve-time (A):** the reranker does NOT suppress noise (it was #1 @0.625),
+  so it should not enter the candidate set at all; plus we don't pay Voyage to embed
+  noise. Retrieve-time would still store/embed/rerank it.
+- **Paired tags, not `if "<tag>" in text`:** a user who quoted `<system-reminder>`
+  without a closing tag survives (≈0 false positives). `Caveat:` is anchored to the full
+  harness sentence, not the bare word.
+- **Retrieve-dedup, not index-skip (B):** the same text in different sessions is
+  legitimate (the surrounding context differs) — index-skip would kill provenance.
+- **No MMR for now:** the measured bug is EXACT duplicates (same hash), which hash collapse solves
+  for free and without tuning; MMR (near-dup) adds a λ knob and the risk of dropping relevant content —
+  deferred to v2 until the need is proven.
+- **Full re-index, not in-place DELETE:** DELETE only removes standalone noise, but does not
+  fix partially-boilerplate rows (their embedding was computed over dirty text → text↔vector drift);
+  re-index has no drift, the index is one-shot under the leak-proof invariant, ~$1–3.
 
-## Что протестировали
+## What was tested
 
-- 8 новых юнит-тестов (5 extract: чистый блоб дропается; appended-reminder → остаток
-  сохраняется; цитата незакрытого тега выживает; caveat+command дропается; offset на
-  сырой строке. 1 store.delete_file. 1 index no-dup-rows. 1 retrieve content_hash
-  collapse + provenance). Сьют 31 passed / 1 deselected (live).
-- Re-index + повторный прогон 30 запросов (ДОКАЗАНО before/after): noise-чанков в
-  индексе **1470 → 6**; запросов с noise-блобом в top-10 **3 → 0** (#6/#8 top-1 сменился
-  с `<task-notification>` на реальный контент); идентичных дублей в top-k **4 → 0**;
-  sessionHit@10 24 → 25. session-match почти не сдвинулась (блобы были из ПРАВИЛЬНОЙ
-  сессии — метрика их и так считала попаданием), но полезность top-чанка выросла — что и цель.
+- 8 new unit tests (5 extract: a pure blob is dropped; appended-reminder → residual is
+  kept; a quote of an unclosed tag survives; caveat+command is dropped; offset on
+  the raw string. 1 store.delete_file. 1 index no-dup-rows. 1 retrieve content_hash
+  collapse + provenance). Suite 31 passed / 1 deselected (live).
+- Re-index + a re-run of the 30 queries (PROVEN before/after): noise chunks in
+  the index **1470 → 6**; queries with a noise blob in top-10 **3 → 0** (#6/#8 top-1 switched
+  from `<task-notification>` to real content); identical duplicates in top-k **4 → 0**;
+  sessionHit@10 24 → 25. session-match barely moved (the blobs came from the CORRECT
+  session — the metric already counted them as a hit), but the usefulness of the top chunk improved — which is the goal.
 
-## Отвергли
+## Rejected
 
-- Retrieve-time фильтр для A — всё равно эмбедит/реранкает мусор.
-- Index-skip дедуп для B — теряет provenance.
-- MMR сейчас — оверинжиниринг для точных дублей; v2.
-- In-place DELETE как миграция — дрейф текст↔вектор на частично-boilerplate строках.
+- A retrieve-time filter for A — still embeds/reranks the noise.
+- Index-skip dedup for B — loses provenance.
+- MMR now — overengineering for exact duplicates; v2.
+- In-place DELETE as the migration — text↔vector drift on partially-boilerplate rows.
 
-Ветка: `fix/extract-noise-dedup`.
+Branch: `fix/extract-noise-dedup`.

--- a/docs/decisions/2026-06-26-recall-project-scope.md
+++ b/docs/decisions/2026-06-26-recall-project-scope.md
@@ -1,75 +1,75 @@
-# Recall умеет сужать поиск до текущего проекта (по cwd, не по project-имени)
+# Recall can narrow the search to the current project (by cwd, not by project name)
 
-**Дата:** 2026-06-26
+**Date:** 2026-06-26
 
-## Контекст
+## Context
 
-`recall_search`/`grep` искали глобально по всему корпусу сессий. При работе над
-конкретным репо это подмешивает шум из других проектов: семантически похожий
-кусок из чужого репо вытесняет нужный из top-k ещё до реранкера. Хотелось
-опционально сужать поиск до текущего проекта, не теряя возможность кросс-проектного
+`recall_search`/`grep` searched globally across the entire session corpus. When working on
+a specific repo this mixes in noise from other projects: a semantically similar
+fragment from a foreign repo crowds the needed one out of top-k before the reranker even runs. We wanted
+to optionally narrow the search to the current project without losing cross-project
 recall.
 
-Решение принимали с советом из 4 движков (Storm: claude+codex+glm+gemini) —
-полный консенсус по всем пунктам, разошлись только в множителе over-fetch.
+The decision was made with a 4-engine council (Storm: claude+codex+glm+gemini) —
+full consensus on every point, diverging only on the over-fetch multiplier.
 
-## Решение
+## Decision
 
-Опциональный `scope_cwd` на `recall_search` и `grep` (по умолчанию отсутствует →
-прежний глобальный поиск). Агент передаёт свой сырой `cwd`; сервер нормализует его
-к корню репо и фильтрует **существующую** колонку `cwd` граничным префиксом. Без
-изменения схемы и без переиндексации.
+An optional `scope_cwd` on `recall_search` and `grep` (absent by default →
+the previous global search). The agent passes its raw `cwd`; the server normalizes it
+to the repo root and filters the **existing** `cwd` column by a bounded prefix. No
+schema change and no reindexing.
 
-- `scope.repo_root(cwd)` — срезает суффикс `/.claude/worktrees/<name>` → все
-  сессии репо (main + каждый worktree) схлопываются в один scope.
-- `scope.scope_clause(column, root)` — общий предикат для KNN и FTS (чтобы логика
-  не разъехалась): `cwd = root OR cwd LIKE root||'/%' ESCAPE '\'`.
-- KNN: vec0 не умеет pre-filter по joined-колонке → over-fetch кандидатов
-  (`clamp(n*30, 300, 2000)`, не больше total) + фильтр через JOIN, LIMIT n.
-- FTS: JOIN `chunks` + предикат до LIMIT (точно, без over-fetch).
+- `scope.repo_root(cwd)` — strips the `/.claude/worktrees/<name>` suffix → all
+  sessions of the repo (main + each worktree) collapse into one scope.
+- `scope.scope_clause(column, root)` — a shared predicate for KNN and FTS (so the logic
+  doesn't drift apart): `cwd = root OR cwd LIKE root||'/%' ESCAPE '\'`.
+- KNN: vec0 cannot pre-filter on a joined column → over-fetch candidates
+  (`clamp(n*30, 300, 2000)`, no more than total) + filter via JOIN, LIMIT n.
+- FTS: JOIN `chunks` + the predicate before LIMIT (exact, no over-fetch).
 
-## Почему
+## Why
 
-- **Ключ = cwd, не `project`-имя.** `_project_name` берёт последний сегмент пути
-  → для worktree даёт мусорный хэш (`-Users-me-myrepo--claude-worktrees-...-a1b2c3`
-  → `a1b2c3`), а почти вся реальная работа идёт в worktree. Фильтр по имени
-  пропустил бы ~90% истории репо и путал бы коллизии (`.../api` → `api`). `cwd` —
-  надёжное поле (реальный абсолютный путь из каждого turn).
-- **Нормализация строкой, не git.** `git rev-parse --show-toplevel` внутри
-  worktree возвращает сам worktree, а не родителя, и падает на удалённых/исторических
-  worktree-путях, хранящихся в индексе. Чистый strip регуляркой работает всегда.
-- **Граница `/%` обязательна.** Без неё `LIKE 'myrepo%'` сожрал бы соседний
-  `myrepo-backend`. LIKE-wildcards в root экранируются.
-- **Default = global, сужение opt-in.** Чисто аддитивно, нулевая регрессия,
-  кросс-проектный recall остаётся дефолтом. Сервер user-scope не знает cwd сам, так
-  что агент передаёт строку явно (политика «по умолчанию scoped» — в промпте
-  subagent/SKILL, не в самом туле).
-- **Сервер нормализует, агент шлёт сырой cwd.** Одна чистая тестируемая функция,
-  без git-зависимости; subagent `recall` без shell не может сам узнать `pwd` —
-  поэтому вызывающий агент кладёт cwd в dispatch.
+- **The key = cwd, not the `project` name.** `_project_name` takes the last path segment
+  → for a worktree it yields a garbage hash (`-Users-me-myrepo--claude-worktrees-...-a1b2c3`
+  → `a1b2c3`), and almost all real work happens in a worktree. Filtering by name
+  would miss ~90% of the repo's history and confuse collisions (`.../api` → `api`). `cwd` is
+  a reliable field (the real absolute path from each turn).
+- **Normalize with a string, not git.** `git rev-parse --show-toplevel` inside a
+  worktree returns the worktree itself, not the parent, and fails on deleted/historical
+  worktree paths stored in the index. A plain regex strip works every time.
+- **The `/%` boundary is mandatory.** Without it `LIKE 'myrepo%'` would swallow the neighboring
+  `myrepo-backend`. LIKE wildcards in root are escaped.
+- **Default = global, narrowing is opt-in.** Purely additive, zero regression,
+  cross-project recall stays the default. The server in user-scope doesn't know cwd itself, so
+  the agent passes the string explicitly (the "scoped by default" policy lives in the
+  subagent/SKILL prompt, not in the tool itself).
+- **The server normalizes, the agent sends the raw cwd.** One clean testable function,
+  no git dependency; the `recall` subagent without a shell cannot learn `pwd` itself —
+  so the calling agent puts cwd into the dispatch.
 
-## Что протестировали
+## What was tested
 
-- 17 новых тестов TDD (RED→GREEN), полная сюита 53 passed, 0 регрессий.
-- `repo_root`: plain-путь, worktree-суффикс, trailing slash, пусто.
-- `scope_clause`: None=без фильтра, exact-or-prefix, экранирование `%`/`_`.
-- store KNN/FTS: фильтр по префиксу + граница `/repo` ≠ `/repo-backend`.
-- retrieve: scoped исключает другой репо; worktree-cwd нормализуется к корню; grep scoped.
-- server: проброс `scope_cwd` end-to-end на реальных данных двух репо.
-- **Гипотеза снята:** боялись, что sqlite-vec отвергнет `MATCH`+`k` с доп. WHERE
-  по joined-колонке (готов был two-step fallback) — установленная версия приняла
-  single-query JOIN, fallback не понадобился.
+- 17 new TDD tests (RED→GREEN), full suite 53 passed, 0 regressions.
+- `repo_root`: plain path, worktree suffix, trailing slash, empty.
+- `scope_clause`: None=no filter, exact-or-prefix, escaping `%`/`_`.
+- store KNN/FTS: prefix filter + boundary `/repo` ≠ `/repo-backend`.
+- retrieve: scoped excludes another repo; worktree cwd normalizes to the root; grep scoped.
+- server: `scope_cwd` passthrough end-to-end on real data from two repos.
+- **Hypothesis dropped:** we feared sqlite-vec would reject `MATCH`+`k` with an extra WHERE
+  on a joined column (a two-step fallback was ready) — the installed version accepted
+  the single-query JOIN, the fallback was not needed.
 
-## Отвергли
+## Rejected
 
-- Фильтр по `project`-имени — битый для worktree, коллизии.
-- `git rev-parse` для корня — возвращает worktree, падает на удалённых путях.
-- Per-repo / партиционированные vec-таблицы — overkill, скан и так дёшев.
-- Денормализация cwd в FTS-таблицу — лишний rebuild, JOIN проще.
-- Чинить битое `_project_name` в этом заходе — cwd обходит его; вынесено в follow-up.
-- Эхо resolved-scope в каждый результат — пока не делаем (сломало бы формат
-  вывода); under-fill закрыт политикой «scoped тонко → повтори global» в промпте.
-- Авто-детект scope сервером — невозможно на user-scope (cwd не передаётся в MCP).
+- Filtering by the `project` name — broken for worktrees, collisions.
+- `git rev-parse` for the root — returns the worktree, fails on deleted paths.
+- Per-repo / partitioned vec tables — overkill, the scan is cheap anyway.
+- Denormalizing cwd into the FTS table — an extra rebuild, JOIN is simpler.
+- Fixing the broken `_project_name` in this pass — cwd bypasses it; moved to a follow-up.
+- Echoing the resolved scope in every result — not doing it yet (would break the output
+  format); under-fill is covered by the "scoped too thin → re-run global" policy in the prompt.
+- Server-side scope auto-detection — impossible in user-scope (cwd is not passed into MCP).
 
 ---
-Реализация: `scope.py` (`repo_root` + `scope_clause`) + проводка в store/retrieve/server; тесты `tests/test_scope.py`.
+Implementation: `scope.py` (`repo_root` + `scope_clause`) + wiring into store/retrieve/server; tests `tests/test_scope.py`.

--- a/docs/decisions/2026-06-26-recall-stay-tool-based-simple.md
+++ b/docs/decisions/2026-06-26-recall-stay-tool-based-simple.md
@@ -1,45 +1,45 @@
-# session-recall остаётся tool-based и простым (дистилляцию отвергли)
+# session-recall stays tool-based and simple (distillation rejected)
 
-**Дата:** 2026-06-26
+**Date:** 2026-06-26
 
-## Контекст
+## Context
 
-Цель: память, чтобы Claude Code, начав сессию и получив задачу, которую мы уже
-проходили, МГНОВЕННО вникал в контекст самым прямым путём — **через tool, не
-ambient**. Я предложил тяжёлый план: два прототипа (A — дистиллированные «брифы
-задач», B — «умная дуга») + бейк-офф. Максим затормозил: «становится слишком
-сложно; я думал, мы просто векторизируем запросы+ответы и работаем над этим».
+Goal: a memory so that Claude Code, when it starts a session and gets a task we've already
+worked through, INSTANTLY gets up to speed by the most direct path — **via a tool, not
+ambient**. I proposed a heavy plan: two prototypes (A — distilled "task
+briefs", B — "smart arc") + a bake-off. Maxim hit the brakes: "this is getting too
+complicated; I thought we'd just vectorize queries+answers and work on that."
 
-## Решение
+## Decision
 
-Остаёмся на текущем tool-based v1 (векторизация surface = промпты юзера + текстовые
-ответы ассистента) + точечные фиксы. Дистилляцию / бейк-офф / ambient НЕ строим.
+Stay on the current tool-based v1 (vectorize surface = user prompts + the assistant's text
+answers) + targeted fixes. We do NOT build distillation / bake-off / ambient.
 
-## Почему (доказано живым тестом на MCP-тулах)
+## Why (proven by a live test on the MCP tools)
 
-- Сыграли реальный «возобнови задачу» (Drop silent-loss) на живых тулах: `recall`
-  нашёл правильную окрестность; нырок `expand_around` в «Итог»-турн отдал готовый
-  бриф — решение + почему + статус + что осталось.
-- **Брифы УЖЕ существуют** в данных, что мы векторизируем — как прошлые «Итог»-ответы
-  ассистента. Отдельный дистилляционный слой не нужен.
-- Реальным блокером был БАГ: `expand_around` дампил ~5 КБ base64 (зашифрованная
-  thinking-подпись) + полный сырой message-конверт на турн → drill-down бесполезен.
-  Починен (`9e2b584`): чистый рендер, 10000+ → 1534 символа.
+- We played out a real "resume the task" (Drop silent-loss) on the live tools: `recall`
+  found the right neighborhood; an `expand_around` dive into the "Итог" (Summary) turn returned a ready
+  brief — decision + why + status + what's left.
+- **Briefs ALREADY exist** in the data we vectorize — as past assistant "Итог" (Summary) answers.
+  A separate distillation layer is not needed.
+- The real blocker was a BUG: `expand_around` dumped ~5 KB of base64 (an encrypted
+  thinking signature) + the full raw message envelope per turn → drill-down was useless.
+  Fixed (`9e2b584`): clean rendering, 10000+ → 1534 characters.
 
-## Отвергли
+## Rejected
 
-- **Дистиллированные «брифы задач»** (отдельный пайплайн) — брифы и так есть как
-  «Итог»-турны; пайплайн = устаревание + стоимость генерации/поддержки.
-- **A/B бейк-офф** — оверинжиниринг под спекулятивный зазор.
-- **Ambient авто-инжект** (v2) — пока on-demand тула достаточно.
-- **MMR** — точечные дубли уже решены `content_hash`-коллапсом.
+- **Distilled "task briefs"** (a separate pipeline) — briefs already exist as
+  "Итог" (Summary) turns; a pipeline = staleness + generation/maintenance cost.
+- **A/B bake-off** — overengineering for a speculative gap.
+- **Ambient auto-inject** (v2) — an on-demand tool is enough for now.
+- **MMR** — exact duplicates are already solved by `content_hash` collapse.
 
-## Остаток (parked — строим только по живому сигналу)
+## Remainder (parked — build only on a live signal)
 
-- **#2 `recall_context(query)`** — один вызов = recall + авто-чистый-expand → читаемые
-  блоки обсуждения вместо сниппетов. НЕ строим, пока реальная боль не покажет, что
-  `recall → expand` (оба теперь чистые) мало.
-- v1.x: индексировать финалки сабагентов (`agent-*`, эпизод #28); summary-bias
-  ранжирования (поднимать «Итог»/решающие турны).
+- **#2 `recall_context(query)`** — one call = recall + auto-clean-expand → readable
+  discussion blocks instead of snippets. NOT building it until real pain shows that
+  `recall → expand` (both now clean) is not enough.
+- v1.x: index subagent finals (`agent-*`, episode #28); summary-bias
+  ranking (lift "Итог" (Summary)/decisive turns).
 
-Принцип: добавляем сложность только когда живое использование докажет нужду.
+Principle: add complexity only when live usage proves the need.

--- a/docs/decisions/2026-06-27-grep-resilient-to-deleted-transcripts.md
+++ b/docs/decisions/2026-06-27-grep-resilient-to-deleted-transcripts.md
@@ -1,85 +1,85 @@
-# grep устойчив к транскриптам, удалённым после индексации
+# grep is resilient to transcripts deleted after indexing
 
-**Дата:** 2026-06-27 · **Ветка:** `fix/grep-resilient-deleted-transcripts`
+**Date:** 2026-06-27 · **Branch:** `fix/grep-resilient-deleted-transcripts`
 
-## Контекст
+## Context
 
-Фидбэк из живого использования (другая сессия, инструмент оценён на 8/10):
-глобальный `grep` (без `session_id`) упал с
+Feedback from live usage (a different session, the tool rated 8/10):
+global `grep` (without `session_id`) crashed with
 
 ```
 [Errno 2] No such file or directory:
 /Users/maxim/.claude/projects/-Users-maxim/98688231-0c4e-471d-aec2-a4ee74efda4f.jsonl
 ```
 
-Гипотеза в фидбэке: путь «битый/обрезанный» (`-Users-maxim` вместо
-`-Users-maxim-xyeta-trend-detection`), вероятно из-за пробела/спецсимвола в пути
-сессии. Вывод фидбэка: точечный grep по `session_id` ок, глобальный ненадёжен.
+Hypothesis in the feedback: the path is "broken/truncated" (`-Users-maxim` instead of
+`-Users-maxim-xyeta-trend-detection`), probably due to a space/special character in the session
+path. Feedback conclusion: targeted grep by `session_id` is fine, global is unreliable.
 
-## Решение
+## Decision
 
-`_read_turns(file_path)` оборачиваем в `try/except OSError → return []`.
-Фикс в **источнике** (единственное место, где открывается файл с диска), а не в
-цикле `grep`. Это покрывает все три читающих диск тула:
+Wrap `_read_turns(file_path)` in `try/except OSError → return []`.
+The fix is at the **source** (the single place where a file is opened from disk), not in the
+`grep` loop. This covers all three disk-reading tools:
 
-- `grep` (скан по всем индексированным путям) — пропавший файл даёт `[]` турнов →
-  ноль хитов от него → скан продолжается;
-- `expand_around` / `step` (точечный drill-down) — мёртвый anchor деградирует до
-  `[]`, что консистентно с их же поведением при ненайденном `uuid`.
+- `grep` (scan over all indexed paths) — a missing file yields `[]` turns →
+  zero hits from it → the scan continues;
+- `expand_around` / `step` (targeted drill-down) — a dead anchor degrades to
+  `[]`, which is consistent with their own behavior on a not-found `uuid`.
 
-**Гигиена индекса (комплемент, тот же заход).** `Store.prune_deleted()` в начале
-`index_corpus`: проходит `indexed_files`, у кого пути нет на диске — выкидывает их
-чанки (`delete_file`: chunks + vec + fts) и строку `indexed_files`. `index_corpus`
-ходит только по существующим файлам, поэтому удалённый сам никогда не подчистится.
-Два слоя defense-in-depth: resilience не даёт упасть **сейчас**, prune убирает
-мёртвые строки, чтобы они не всплывали и в `recall_search` (где текст живёт в БД, а
-drill-down по такому хиту вернул бы пусто).
+**Index hygiene (complement, same pass).** `Store.prune_deleted()` at the start of
+`index_corpus`: it walks `indexed_files`, and for those whose path is not on disk — drops their
+chunks (`delete_file`: chunks + vec + fts) and the `indexed_files` row. `index_corpus`
+only walks existing files, so a deleted one would never clean itself up.
+Two layers of defense-in-depth: resilience keeps it from crashing **now**, prune removes
+dead rows so they don't surface in `recall_search` either (where the text lives in the DB, and a
+drill-down on such a hit would return nothing).
 
-## Почему
+## Why
 
-Диагностика опровергла гипотезу фидбэка. Замер по реальному индексу:
+Diagnosis disproved the feedback hypothesis. Measurement against the real index:
 
-- `~/.claude/projects/-Users-maxim/` **существует** — это валидный project-dir для
-  сессий, запущенных из home `/Users/maxim` (23 `.jsonl`). Путь не обрезан, кодировка
-  корректна.
-- Из **338** индексированных `file_path` на диске нет ровно **одного** — того самого
-  `98688231-…jsonl`. Файл был **удалён после индексации**; его чанки остались в БД и
-  указывают на исчезнувший путь.
+- `~/.claude/projects/-Users-maxim/` **exists** — it is a valid project dir for
+  sessions launched from home `/Users/maxim` (23 `.jsonl`). The path is not truncated, the encoding
+  is correct.
+- Of the **338** indexed `file_path` entries, exactly **one** is missing from disk — that very
+  `98688231-…jsonl`. The file was **deleted after indexing**; its chunks remained in the DB and
+  point at the vanished path.
 
-Корень — не кодировка пути, а отсутствие устойчивости слоя чтения к
-файлу-призраку. Глобальный grep обходит КАЖДЫЙ индексированный путь, поэтому
-гарантированно натыкается на любой удалённый файл и роняет весь скан одним
-`open()`. Session-scoped grep тот файл просто не трогает — отсюда «точечный ок,
-глобальный падает».
+The root cause is not path encoding, but the lack of resilience in the read layer to a
+ghost file. Global grep walks EVERY indexed path, so it is
+guaranteed to hit any deleted file and crash the whole scan on a single
+`open()`. Session-scoped grep simply never touches that file — hence "targeted is fine,
+global crashes".
 
-`OSError` (а не только `FileNotFoundError`) — ловим заодно и нечитаемый из-за прав
-файл: для скана любой непрочитанный файл = пропустить, не падать.
+`OSError` (rather than only `FileNotFoundError`) — also catches a file unreadable due to
+permissions: for a scan, any unreadable file = skip, don't crash.
 
-## Что протестировали
+## What was tested
 
-- RED-тест `test_grep_skips_missing_files_global`: два чанка, один → живой файл с
-  иглой, другой → путь, которого нет на диске; глобальный grep обязан вернуть живые
-  хиты и не упасть. Падал с тем же `FileNotFoundError` в `retrieve.py:81`, что и в
-  проде → после фикса зелёный.
-- Живой индекс: `grep("VOYAGE_API_KEY")` без `session_id` (обходит все файлы,
-  включая удалённый) → 688 хитов вместо краша.
-- RED-тест `test_index_prunes_chunks_for_deleted_transcripts`: индексируем 2 файла,
-  один удаляем с диска, ре-индекс → его чанки (+ vec/fts + строка `indexed_files`)
-  выпилены, живой файл цел. Падал (1 ≠ 0) до прунинга → зелёный.
-- Живой индекс: `prune_deleted()` → выпилен 1 файл (тот самый `98688231-…`); после —
-  0 чанков указывают на несуществующий путь.
-- Полный набор: 60 passed, 0 регрессий.
+- RED test `test_grep_skips_missing_files_global`: two chunks, one → a live file with
+  the needle, the other → a path that is not on disk; global grep must return the live
+  hits and not crash. It failed with the same `FileNotFoundError` in `retrieve.py:81` as in
+  prod → green after the fix.
+- Live index: `grep("VOYAGE_API_KEY")` without `session_id` (walks all files,
+  including the deleted one) → 688 hits instead of a crash.
+- RED test `test_index_prunes_chunks_for_deleted_transcripts`: index 2 files,
+  delete one from disk, re-index → its chunks (+ vec/fts + the `indexed_files` row) are
+  pruned, the live file is intact. It failed (1 ≠ 0) before pruning → green.
+- Live index: `prune_deleted()` → 1 file pruned (that very `98688231-…`); afterward —
+  0 chunks point at a nonexistent path.
+- Full suite: 60 passed, 0 regressions.
 
-## Отвергли
+## Rejected
 
-- **Гипотеза «битый/обрезанный путь» (из фидбэка)** — опровергнута замером: dir
-  валиден, кодировка корректна, файл просто удалён.
-- **Ловить ошибку в цикле `grep`** — чинит только grep; `expand_around`/`step`
-  остались бы хрупкими на мёртвом anchor. Фикс в источнике покрывает всех.
-- **Прунинг как ЕДИНСТВЕННЫЙ фикс** — не убирает краш сам по себе (гонка: файл
-  могут удалить между индексацией и чтением, в том же запуске). Поэтому прунинг
-  взят **комплементом** к resilience (оба в этом заходе), а не заменой.
+- **The "broken/truncated path" hypothesis (from the feedback)** — disproved by measurement: the dir
+  is valid, the encoding is correct, the file was simply deleted.
+- **Catching the error in the `grep` loop** — fixes only grep; `expand_around`/`step`
+  would stay fragile on a dead anchor. The fix at the source covers them all.
+- **Pruning as the SOLE fix** — it doesn't remove the crash by itself (a race: a file
+  can be deleted between indexing and reading, in the same run). So pruning is
+  taken as a **complement** to resilience (both in this pass), not a replacement.
 
-Фидбэк-эргономика (не баги, отдельно): нет примитива «хвост сессии / свежие
-сессии»; индекс-freshness не виден агенту; тред размазан по нескольким `session_id`
-(нет склейки по worktree/треду); `when` — сырой epoch.
+Feedback ergonomics (not bugs, separate): there is no "session tail / recent
+sessions" primitive; index freshness is not visible to the agent; a thread is spread across several `session_id`
+(no stitching by worktree/thread); `when` is a raw epoch.

--- a/docs/decisions/2026-06-27-recall-ergonomics-when-and-recent-sessions.md
+++ b/docs/decisions/2026-06-27-recall-ergonomics-when-and-recent-sessions.md
@@ -1,0 +1,89 @@
+# Recall ergonomics: human-readable timestamps + recent_sessions
+
+**Date:** 2026-06-27 · **Branch:** `chore/recall-feedback-tails`
+
+## Context
+
+The same live-usage feedback that surfaced the grep crash (see
+`2026-06-27-grep-resilient-to-deleted-transcripts.md`) also listed three ergonomics
+rough edges (not bugs):
+
+- `when` is surfaced as a raw epoch int — hard to tell "now" from "old".
+- No "session tail / recent sessions" primitive, and the index freshness is not
+  visible to the agent: to find the current state you had to sort hits by `when`
+  and expand them by hand.
+- A single thread is spread across several `session_id`s (resume creates new
+  session files); the tool does not stitch them, so the arc was assembled by hand.
+
+## Decision
+
+- **`when_human`.** A `timefmt.humanize_ts(ts, now)` helper renders an epoch as
+  `YYYY-MM-DD HH:MM UTC (Nx ago)`. The server enriches every ranked anchor
+  (`recall_search`, `grep`) with a `when_human` field; the raw `when` epoch stays
+  for sorting. `now` is injected (not read from the clock) so it is testable.
+- **`recent_sessions(scope_cwd=None, limit=10)`** — a new read-only MCP tool. Lists
+  sessions by most-recent activity (freshest first), each with `session_id`,
+  `project`, `turns`, `last_activity` (epoch), `last_activity_human`, and a `label`
+  (the session's first user prompt). Scoped via the existing `scope_cwd`/`repo_root`
+  machinery.
+
+This single tool covers two of the three asks directly — "freshest sessions /
+session tail" and "how fresh is the index" (the top entry's `last_activity_human`
+IS the effective freshness) — and substantially addresses the third: scoped,
+recency-ordered sessions let the agent SEE the thread's sessions and reassemble the
+arc without manual sorting.
+
+## Why
+
+These came from real friction, not speculation, so they are worth closing. But they
+stay small and read-only: no new storage, no schema change, no reindex, no ambient
+behavior — consistent with the project's "stay tool-based and simple" stance
+(`2026-06-26-recall-stay-tool-based-simple.md`). `recent_sessions` is one cheap
+GROUP BY over the existing `chunks` table plus a label lookup per row (limit is
+small).
+
+## What was tested
+
+- `test_humanize_ts_absolute_and_relative` — empty for ts=0, relative buckets
+  (just now / m / h / d) and the absolute UTC stamp.
+- `test_recent_sessions_orders_scopes_and_labels` — freshest-first ordering, repo
+  scoping, first-user-prompt label, turn count.
+- `test_recall_search_enriches_with_human_timestamp` + delegation/scope test for the
+  new tool at the server layer.
+- Full suite: 64 passed, 0 regressions.
+- Live index: `recent_sessions(scope_cwd=~/sidekey)` returned the three freshest
+  sidekey sessions with readable "Nm ago" times, turn counts, and prompt labels.
+
+## Rejected
+
+- **Auto-stitching a thread across `session_id`s into one logical conversation** —
+  would need a reliable cross-session link (how Claude Code chains resume sessions)
+  and a merge heuristic; doing it blind risks wrong merges, which is worse than
+  none. Deferred as a design item. `recent_sessions` covers the practical need
+  (see the thread's sessions, ordered) without the risk.
+- **A separate `index_freshness` / `index_status` tool** — folded into
+  `recent_sessions` (its newest entry is the freshness signal) to avoid extra
+  surface for the same information.
+- **Changing `when` from epoch to a string** — would break sorting and is a
+  breaking change to the anchor shape; added `when_human` alongside instead.
+
+## Plugin tool namespacing fix (same pass)
+
+While deduplicating the manual MCP registration against the installed plugin, the
+manual user-scope `session-recall` MCP server was removed, leaving only the plugin's
+bundled MCP. The plugin's `agents/recall.md` (`tools:` allowlist) and
+`skills/session-recall/SKILL.md` referenced the tools by the **bare** form
+`mcp__session-recall__<tool>` — which only resolved while the manual server existed.
+In a plugin-only install the tools are namespaced
+`mcp__plugin_session-recall_session-recall__<tool>`, so the bare names silently
+resolved to nothing: a forcing test (asking the recall subagent about a topic only
+in the transcripts) showed it returned NO session_id/uuid anchors and reconstructed
+from git logs / memory files via `Read` instead — i.e. it had lost its recall tools.
+External plugin-only users never had the manual server, so the subagent was broken
+for them from the start.
+
+Fix: `recall.md` lists tools in BOTH the plugin-namespaced and bare forms (unknown
+names are silently ignored, so listing both resolves in either install mode);
+`SKILL.md` refers to tools by bare name in prose (the agent maps to whatever it
+has). Takes effect on the next Claude Code session (the plugin loads its agent
+definition at startup).

--- a/skills/session-recall/SKILL.md
+++ b/skills/session-recall/SKILL.md
@@ -16,8 +16,9 @@ familiar, check; it is cheap.
 Do NOT use for brand-new tasks with no plausible history, or trivial one-offs.
 
 ## Two ways to recall (pick by depth)
-- **Quick check** — call `mcp__session-recall__recall_search("<topic>")` yourself. Good for
-  "did we ever discuss X?": ranked snippets in one call.
+- **Quick check** — call the `recall_search` tool yourself (from the session-recall MCP server).
+  Good for "did we ever discuss X?": ranked snippets in one call. The `recent_sessions` tool lists
+  the freshest past sessions when you want "what's the latest / how current is the index".
 - **Deep grounding** — dispatch the **`recall` subagent** (Agent tool,
   `subagent_type: session-recall:recall`) with the topic. It searches deeply, reads the raw arc
   itself, and returns ONLY a tight brief (task / decisions+why / tried-rejected / current state /
@@ -25,7 +26,7 @@ Do NOT use for brand-new tasks with no plausible history, or trivial one-offs.
   snippet.
 
 ## Scoping to the current project
-`recall_search` and `grep` take an optional `scope_cwd`. Pass your current working directory to
+`recall_search`, `grep` and `recent_sessions` take an optional `scope_cwd`. Pass your current working directory to
 restrict results to the current project/repo — worktrees collapse to the repo root automatically,
 so the main checkout and every worktree share one scope. This cuts cross-project noise and sharpens
 the top hits; make it your default for repo-local questions.

--- a/src/session_recall/retrieve.py
+++ b/src/session_recall/retrieve.py
@@ -1,11 +1,13 @@
 # src/session_recall/retrieve.py
 import json
+import time
 from pathlib import Path
 from .store import Store
 from .embed import Embedder
 from .rerank import Reranker
 from .models import Anchor, Turn
 from .scope import repo_root, scope_clause
+from .timefmt import humanize_ts
 
 def _snippet(text: str, n: int = 200) -> str:
     return text[:n] + ("…" if len(text) > n else "")
@@ -192,3 +194,24 @@ class Recall:
                                        snippet=_snippet(blob), score=1.0, project=project,
                                        when=0))
         return hits
+
+    def recent_sessions(self, scope_cwd: str | None = None, limit: int = 10,
+                        now: int | None = None) -> list[dict]:
+        # Freshest sessions first — answers "what's the current state / how fresh is
+        # the index" (the top entry's last_activity IS the effective freshness) and
+        # surfaces the sessions of a thread spread across resume-created session_ids,
+        # so the arc can be reassembled without manual sorting. now is injectable for
+        # deterministic tests. WHY: docs/decisions/2026-06-27-recall-ergonomics-when-and-recent-sessions.md
+        root = repo_root(scope_cwd) if scope_cwd else None
+        now = int(time.time()) if now is None else now
+        out: list[dict] = []
+        for sid, project, last_ts, turns in self.store.recent_sessions(root, limit):
+            out.append({
+                "session_id": sid,
+                "project": project,
+                "turns": turns,
+                "last_activity": last_ts,
+                "last_activity_human": humanize_ts(last_ts, now),
+                "label": _snippet(self.store.first_user_text(sid), 120),
+            })
+        return out

--- a/src/session_recall/server.py
+++ b/src/session_recall/server.py
@@ -1,4 +1,5 @@
 # src/session_recall/server.py
+import time
 from dataclasses import asdict
 from mcp.server.fastmcp import FastMCP
 from .config import DB_PATH
@@ -6,9 +7,18 @@ from .store import Store
 from .embed import make_embedder
 from .rerank import make_reranker
 from .retrieve import Recall
+from .timefmt import humanize_ts
 
 mcp = FastMCP("session-recall")
 _recall: Recall | None = None
+
+
+def _adict(a) -> dict:
+    # Enrich an Anchor with a human-readable timestamp; `when` stays the raw epoch
+    # for sorting, `when_human` makes "now vs old" legible at the tool boundary.
+    d = asdict(a)
+    d["when_human"] = humanize_ts(a.when, int(time.time()))
+    return d
 
 
 def build_recall() -> Recall:
@@ -33,7 +43,7 @@ def recall_search(query: str, k: int = 10, scope_cwd: str | None = None) -> list
     current project/repo (worktrees collapse to the repo root). Omit it for a
     global, cross-project search.
     """
-    return [asdict(a) for a in _r().recall_search(query, k=k, scope_cwd=scope_cwd)]
+    return [_adict(a) for a in _r().recall_search(query, k=k, scope_cwd=scope_cwd)]
 
 
 @mcp.tool()
@@ -55,7 +65,22 @@ def grep(pattern: str, session_id: str | None = None, scope_cwd: str | None = No
     scope_cwd: pass your current working directory to restrict the scan to the
     current project/repo; omit for a global scan.
     """
-    return [asdict(a) for a in _r().grep(pattern, session_id, scope_cwd=scope_cwd)]
+    return [_adict(a) for a in _r().grep(pattern, session_id, scope_cwd=scope_cwd)]
+
+
+@mcp.tool()
+def recent_sessions(scope_cwd: str | None = None, limit: int = 10) -> list[dict]:
+    """List the most recently active past sessions, freshest first — use to see the
+    current state of work and how fresh the index is (the top entry's
+    last_activity_human is the effective freshness). Also surfaces the sessions of a
+    thread split across resume-created session_ids so you can reassemble the arc.
+
+    scope_cwd: pass your current working directory to restrict to the current
+    project/repo (worktrees collapse to the repo root); omit for all projects.
+    Each entry: session_id, project, turns, last_activity (epoch),
+    last_activity_human, label (the session's first user prompt).
+    """
+    return _r().recent_sessions(scope_cwd=scope_cwd, limit=limit)
 
 
 def main():

--- a/src/session_recall/store.py
+++ b/src/session_recall/store.py
@@ -125,6 +125,24 @@ class Store:
             data[k] = int(data[k])
         return Chunk(**data)
 
+    def recent_sessions(self, scope_root: str | None, limit: int) -> list[tuple]:
+        """Sessions by most-recent activity (max ts), optionally scoped to a repo.
+        Returns (session_id, project, last_ts, turns). Tiebreak on session_id so
+        equal-timestamp ordering is deterministic."""
+        clause, params = scope_clause("cwd", scope_root)
+        where = f" WHERE {clause}" if clause else ""
+        return self.db.execute(
+            f"SELECT session_id, project, max(ts) AS last_ts, count(*) AS turns "
+            f"FROM chunks{where} GROUP BY session_id ORDER BY last_ts DESC, session_id LIMIT ?",
+            (*params, limit)).fetchall()
+
+    def first_user_text(self, session_id: str) -> str:
+        """The session's earliest user prompt — a human label for the session."""
+        row = self.db.execute(
+            "SELECT text FROM chunks WHERE session_id = ? AND role = 'user' "
+            "ORDER BY turn_index LIMIT 1", (session_id,)).fetchone()
+        return row[0] if row else ""
+
     def mark_indexed(self, path: str, sig: str):
         self.db.execute(
             "INSERT INTO indexed_files(path, sig) VALUES (?, ?) "

--- a/src/session_recall/timefmt.py
+++ b/src/session_recall/timefmt.py
@@ -1,0 +1,25 @@
+from datetime import datetime, timezone
+
+
+def humanize_ts(ts: int, now: int) -> str:
+    """Render an epoch timestamp as 'YYYY-MM-DD HH:MM UTC (Nx ago)' for humans.
+
+    The index stores `ts` as a raw epoch int; surfaced verbatim it reads as an
+    opaque number, making it hard to tell "now" from "old". `now` is passed in
+    (not read from the clock) so the formatting is deterministic and testable.
+    ts == 0 (unknown — e.g. grep hits carry no timestamp) -> "" so callers can
+    show nothing rather than a fake 1970 date.
+    """
+    if not ts:
+        return ""
+    stamp = datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    delta = max(0, now - ts)
+    if delta < 60:
+        rel = "just now"
+    elif delta < 3600:
+        rel = f"{delta // 60}m ago"
+    elif delta < 86400:
+        rel = f"{delta // 3600}h ago"
+    else:
+        rel = f"{delta // 86400}d ago"
+    return f"{stamp} ({rel})"

--- a/tests/test_retrieve.py
+++ b/tests/test_retrieve.py
@@ -185,6 +185,41 @@ def test_grep_scoped_to_repo(tmp_path):
     store.close()
 
 
+def test_recent_sessions_orders_scopes_and_labels(tmp_path):
+    """recent_sessions surfaces the freshest sessions first (the 'what's current /
+    how fresh' need from feedback), scoped to the repo, each labelled by its first
+    user prompt. The top entry's last_activity is the effective index freshness."""
+    import hashlib
+    from session_recall.models import Chunk
+
+    def mk(sid, uuid, text, cwd, ts, role, turn):
+        return Chunk(session_id=sid, uuid=uuid, role=role, text=text, project="p",
+                     cwd=cwd, git_branch="b", ts=ts, file_path="/f.jsonl", byte_offset=0,
+                     byte_len=5, turn_index=turn,
+                     content_hash=hashlib.sha256((uuid + text).encode()).hexdigest())
+
+    store = Store(tmp_path / "rs.db")
+    emb = FakeEmbedder()
+    v = emb.embed_documents(["x"])[0]
+    store.add(mk("sA", "a1", "question alpha", "/Users/me/repoA", 100, "user", 0), v)
+    store.add(mk("sA", "a2", "answer alpha", "/Users/me/repoA", 150, "assistant", 1), v)
+    store.add(mk("sB", "b1", "question beta", "/Users/me/repoA", 300, "user", 0), v)
+    store.add(mk("sC", "c1", "question gamma", "/Users/me/repoB", 500, "user", 0), v)
+    r = Recall(store, emb, None)
+
+    glob = r.recent_sessions(limit=10, now=1000)
+    assert [s["session_id"] for s in glob] == ["sC", "sB", "sA"]  # newest first
+    assert glob[0]["last_activity"] == 500
+    assert "ago" in glob[0]["last_activity_human"]
+
+    scoped = r.recent_sessions(scope_cwd="/Users/me/repoA", limit=10, now=1000)
+    assert [s["session_id"] for s in scoped] == ["sB", "sA"]  # repoB excluded
+    sA = next(s for s in scoped if s["session_id"] == "sA")
+    assert sA["label"].startswith("question alpha")  # first USER prompt, not the answer
+    assert sA["turns"] == 2
+    store.close()
+
+
 def test_grep_skips_missing_files_global(tmp_path):
     """Regression: a transcript indexed earlier but later DELETED from disk must
     not crash a global grep. grep iterates every indexed file_path; one missing

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -46,6 +46,26 @@ def test_recall_search_forwards_scope_cwd(tmp_path, monkeypatch):
     store.close()
 
 
+def test_recall_search_enriches_with_human_timestamp(tmp_path, monkeypatch):
+    store = Store(tmp_path / "h.db")
+    store.add(*_mk("u1", "alpha", "/Users/me/repoA", 0))
+    monkeypatch.setattr(server, "_recall", Recall(store, FakeEmbedder(), FakeReranker()))
+    out = server.recall_search("alpha", k=1)
+    assert out and "when_human" in out[0], "raw epoch not enriched with when_human"
+    store.close()
+
+
+def test_recent_sessions_tool_delegates_and_scopes(tmp_path, monkeypatch):
+    store = Store(tmp_path / "rs.db")
+    store.add(*_mk("u1", "hello", "/Users/me/repoA", 0, session_id="s1"))
+    store.add(*_mk("u2", "hello", "/Users/me/repoB", 1, session_id="s2"))
+    monkeypatch.setattr(server, "_recall", Recall(store, FakeEmbedder(), FakeReranker()))
+    out = server.recent_sessions(scope_cwd="/Users/me/repoA")
+    assert [s["session_id"] for s in out] == ["s1"], "recent_sessions did not scope to repo"
+    assert "last_activity_human" in out[0]
+    store.close()
+
+
 def test_grep_forwards_scope_cwd(tmp_path, monkeypatch):
     fa = tmp_path / "a.jsonl"
     fa.write_text('{"type":"user","uuid":"u1","sessionId":"sa",'

--- a/tests/test_timefmt.py
+++ b/tests/test_timefmt.py
@@ -1,0 +1,12 @@
+from session_recall.timefmt import humanize_ts
+
+
+def test_humanize_ts_absolute_and_relative():
+    now = 1_700_000_000
+    assert humanize_ts(0, now) == ""              # unknown ts (e.g. grep hits) -> empty
+    assert "just now" in humanize_ts(now, now)
+    assert "5m ago" in humanize_ts(now - 300, now)
+    assert "3h ago" in humanize_ts(now - 3 * 3600, now)
+    assert "2d ago" in humanize_ts(now - 2 * 86400, now)
+    full = humanize_ts(now, now)
+    assert "UTC" in full and full.startswith("20")  # ISO-ish absolute stamp present


### PR DESCRIPTION
## What

Clears the remaining live-feedback ergonomics tails, plus repo/plugin cleanup, in one pass.

### Ergonomics (from the 8/10 feedback)
- **`recent_sessions(scope_cwd=None, limit=10)`** — a new read-only MCP tool listing the
  freshest past sessions first (session_id, project, turns, last_activity + `last_activity_human`,
  and a `label` = the session's first user prompt). Answers "what's the current state / how fresh
  is the index" (the top entry's timestamp IS the freshness) and surfaces a thread's
  resume-split `session_id`s ordered by recency.
- **`when_human`** — ranked anchors (`recall_search`, `grep`) now carry a readable
  `YYYY-MM-DD HH:MM UTC (Nx ago)` timestamp next to the raw epoch (`timefmt.humanize_ts`, `now`
  injected for testability).

### Docs / i18n
- Translated all `docs/decisions/*.md` to English for the public repo (only the literal `"Итог"`
  data value kept, glossed — it names actual stored corpus data).
- README: tool list + `scope_cwd`/`when_human` notes updated.

### Plugin tool namespacing fix
The plugin's `agents/recall.md` (`tools:` allowlist) and `SKILL.md` referenced the **bare**
`mcp__session-recall__*` tool names, which only resolved while a manual MCP server was registered.
In a plugin-only install the tools are `mcp__plugin_session-recall_session-recall__*`, so the bare
names silently resolved to nothing — a forcing test showed the recall subagent returning **no**
session anchors and reconstructing from git logs / memory via `Read`. External plugin-only users
were affected from the start. Now the agent lists both the plugin-namespaced and bare forms
(unknown names are ignored, so it resolves either way); skill prose uses bare names. Takes effect
next Claude Code session.

### Chore
- gitignore the `maxim/` scratch dir; removed a stale local worktree.

## Verification
- **64 tests pass, 0 regressions** (+4: timefmt, recent_sessions ordering/scope/label, server
  enrich + delegate).
- Live index: `recent_sessions(scope_cwd=~/sidekey)` returned the freshest sidekey sessions with
  readable "Nm ago" times, turn counts, and prompt labels.

WHY: `docs/decisions/2026-06-27-recall-ergonomics-when-and-recent-sessions.md`
