### PR TITLE
Add unified Claude Code and Codex session recall

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,6 @@
 {
   "name": "session-recall-marketplace",
+  "description": "Local shared-memory plugin for Claude Code and Codex sessions.",
   "owner": { "name": "max" },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session-recall",
-  "version": "0.2.0",
-  "description": "Semantic recall over your Claude Code session history — resume past tasks instantly. Bundles the MCP search tools, a Sonnet retrieval subagent (deep search in its own context, clean brief back), a trigger skill, and a background freshness hook.",
+  "version": "0.3.0",
+  "description": "Shared semantic recall over local Claude Code and Codex session history. Bundles MCP search tools, a deep-recall subagent, a trigger skill, and a background freshness hook.",
   "author": { "name": "max" }
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "session-recall",
+  "version": "0.3.0+codex.20260710121949",
+  "description": "Shared semantic recall over local Claude Code and Codex session history.",
+  "author": {
+    "name": "max"
+  },
+  "homepage": "https://github.com/AbsoluteMode/session-recall",
+  "repository": "https://github.com/AbsoluteMode/session-recall",
+  "license": "MIT",
+  "keywords": [
+    "memory",
+    "recall",
+    "sessions",
+    "claude-code",
+    "codex"
+  ],
+  "skills": "./skills/",
+  "mcpServers": {
+    "session-recall": {
+      "command": "/bin/sh",
+      "args": [
+        "-c",
+        "export PATH=\"$HOME/.local/bin:$HOME/bin:$PATH\"; exec session-recall-mcp"
+      ]
+    }
+  },
+  "interface": {
+    "displayName": "Session Recall",
+    "shortDescription": "Recall work from Claude Code and Codex.",
+    "longDescription": "Search one local semantic index of your Claude Code and Codex sessions, then drill into the original conversational trace.",
+    "developerName": "max",
+    "category": "Productivity",
+    "capabilities": [
+      "Read"
+    ],
+    "defaultPrompt": [
+      "Recall what we decided about this task.",
+      "Find the latest session for this project."
+    ]
+  }
+}

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,5 @@
-# Скопируй в .env (он в .gitignore — НИКОГДА не коммить настоящий ключ).
+# Example only: export these variables or load them with your secrets manager.
+# session-recall does not auto-load .env files. Never commit a real key.
 
 # Voyage embeddings (https://www.voyageai.com)
 VOYAGE_API_KEY=
-
-# Tip: you can also export the key from your own secrets manager instead of a .env file.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # session-recall
 
-Local, agentic **semantic recall over your Claude Code session history**. It gives the
+Local, agentic **semantic recall over your Claude Code and Codex session history**. Both
+hosts feed one index, so either agent can recover context created by the other. It gives the
 agent five tools (via MCP) so it can resume past work instead of making you re-explain it:
 
 - `recall_search(query)` — find a past discussion **by meaning** (not substring).
@@ -15,23 +16,31 @@ On-demand (no proactive auto-injection in v1). Local, open source.
 `recall_search`, `grep` and `recent_sessions` also take an optional `scope_cwd` — pass your
 current working directory to scope results to the current repo (worktrees collapse to the repo
 root); omit it for cross-project recall. Ranked hits carry a human-readable `when_human`
-timestamp alongside the raw epoch.
+timestamp alongside the raw epoch. Every MCP tool accepts an optional `source` (`claude` or
+`codex`); omit it to use the unified history. Results include provenance as `source=claude` or
+`source=codex`.
 
 **Status:** v1, built and validated on real history. Key design rationale lives in
 [docs/decisions/](docs/decisions/).
 
 ## How it works
 
-Only the conversation "surface" is indexed — user prompts and assistant text replies.
-`tool_result` / `thinking` / harness noise are not embedded but stay reachable via
-`expand_around` / `grep`. Embeddings: Voyage `voyage-4-large` (dim 1024) → SQLite
+Claude Code transcripts and Codex sessions from `~/.codex/sessions` plus
+`~/.codex/archived_sessions` share the same index.
+Only the conversation "surface" is embedded — user prompts and assistant text replies.
+Tool calls, results, reasoning, and other trace data are not embedded but stay reachable on
+demand via `expand_around` (and `step`) or `grep`. Raw Codex transcript files remain local;
+only the extracted conversation surface is sent to the configured embedding provider.
+
+Embeddings: Voyage `voyage-4-large` (dim 1024) → SQLite
 (`sqlite-vec` KNN + FTS5, bm25-ranked) → Voyage `rerank-2.5` → top-k. Indexing is
-incremental (by mtime+size) and cheap on live transcripts: they are append-only, so
+incremental (by file metadata, including Codex inode+size) and cheap on live transcripts: they are append-only, so
 unchanged chunks are matched by content hash and their vectors reused — only new turns
-hit the embedding API. Each file indexes in its own transaction; a failing file is
-logged and retried on the next run, never aborting the rest. Subagent sidechains
-(`<session>/subagents/`) are intentionally skipped — that's under-the-hood tooling,
-not conversation.
+hit the embedding API. Moving a Codex rollout into the archive also reuses its existing
+vectors. Each file indexes in its own transaction; a failing file is
+logged and retried on the next run, never aborting the rest. Claude sidechains
+(`<session>/subagents/`) and Codex spawned-subagent sessions are intentionally skipped —
+they are under-the-hood tooling, not the primary user/agent conversation.
 
 Embeddings are pluggable (Voyage is the default); the reranker is optional, and the
 system degrades gracefully to KNN + FTS without one. Switching the embedding
@@ -40,49 +49,72 @@ signature) and triggers a clean re-embed instead of silently mixing vector space
 
 ## Install / run
 
+For normal use with the bundled Claude Code/Codex plugins, install the two CLI entrypoints on
+your user `PATH` (the manifests also check `~/.local/bin`):
+
 ```bash
-python -m venv .venv && .venv/bin/pip install -e .
+pipx install --editable .
 export VOYAGE_API_KEY=...                        # your Voyage key
 
-.venv/bin/session-recall index                   # index ~/.claude/projects
-.venv/bin/session-recall search "query"          # semantic search from the CLI
-.venv/bin/session-recall recent                  # freshest sessions (is the index current?)
-.venv/bin/session-recall grep "exact string"     # raw substring scan, no API needed
-.venv/bin/session-recall prune                   # drop rows for deleted transcripts
+session-recall index                             # both sources (same as --source all)
+session-recall index --source claude             # only ~/.claude/projects
+session-recall index --source codex              # active + archived Codex sessions
+session-recall search "query"                    # unified semantic search
+session-recall search "query" --source codex
+session-recall recent --source claude            # freshest Claude sessions
+session-recall grep "exact" --source codex --limit 100  # raw scan, no API needed
+session-recall prune                             # drop rows for deleted transcripts
 ```
 
-### Connect to Claude Code (MCP)
+For repository development or manual MCP registration, an in-tree virtualenv works too:
+
+```bash
+python -m venv .venv && .venv/bin/pip install -e .
+.venv/bin/session-recall index
+```
+
+`index --source` accepts `all`, `claude`, or `codex` and defaults to `all`. `search`,
+`recent`, `grep`, and `prune` accept optional `--source claude|codex`; omit it for both.
+Raw `grep` returns at most 100 matches by default; use `--limit` to adjust the cap.
+
+### Connect to Claude Code or Codex (MCP)
+
+The repo includes both Claude Code and Codex plugin manifests around the same MCP server and
+recall skill. To register the server manually in Claude Code:
 
 ```bash
 claude mcp add session-recall --scope user -- \
   /absolute/path/.venv/bin/python -m session_recall.server
 ```
 
-The server reads `VOYAGE_API_KEY` from the environment; the tools (`recall_search` and
-friends) become available to the agent in new sessions. Verify with
-`claude mcp list` → `✔ Connected`.
+The server reads `VOYAGE_API_KEY` from the environment. For Codex, the
+`.codex-plugin/plugin.json` manifest is ready to place in a local repo or personal marketplace;
+follow the [local plugin installation guide](https://learn.chatgpt.com/docs/build-plugins#install-a-local-plugin-manually).
+In Claude Code, verify with `claude mcp list` → `✔ Connected`. Start a new session/task after
+enabling the plugin so the MCP tools and skill are loaded.
 
 ## Keeping the index fresh
 
 Indexing is incremental (it skips already-indexed files by signature), so staying fresh is
-cheap. The most direct way is a Claude Code `SessionStart` hook that runs
-`session-recall index` in the background at the start of each session. In
-`~/.claude/settings.json`:
+cheap. The plugin's bundled `SessionStart` hook is compatible with both hosts and runs
+`session-recall index` in the background; the default `--source all` refreshes both histories.
+Codex requires a one-time review/trust of newly installed or changed hooks through `/hooks`.
+For a manual Claude Code hook in `~/.claude/settings.json`:
 
 ```json
 "hooks": {
   "SessionStart": [
     { "hooks": [ {
       "type": "command",
-      "async": true,
-      "command": "pgrep -f 'session-recall index' >/dev/null 2>&1 || (VOYAGE_API_KEY=... /abs/path/.venv/bin/session-recall index >/tmp/sr-index.log 2>&1 &)"
+      "command": "sr=/abs/path/.venv/bin/session-recall; pgrep -f \"$sr index\" >/dev/null 2>&1 || (VOYAGE_API_KEY=... \"$sr\" index >/tmp/sr-index.log 2>&1 &)"
     } ] }
   ]
 }
 ```
 
 The `pgrep` guard prevents overlapping runs; `( … & )` detaches so session start doesn't
-wait. A `launchd`/cron timer works too. (Local on one machine is enough; a server-side
+wait. Keep the host-level hook synchronous: the shell already backgrounds the indexer, and
+Codex ignores Claude's `async` extension. A `launchd`/cron timer is another option. (Local on one machine is enough; a server-side
 index only makes sense across several machines — at the cost of privacy and network.)
 
 ## Privacy — hard invariant
@@ -93,6 +125,9 @@ This is a public repository. **Only code goes in it.**
   **outside the repo tree**. They physically cannot be committed.
 - API keys → environment only (`VOYAGE_API_KEY`); `.gitignore` blocks `.env`.
 - Tests → synthetic fixtures only, never a real slice of a session.
+- Claude Code transcripts plus active and archived Codex transcripts are read locally. Only
+  user/assistant surface text is embedded; tool/reasoning trace data stays out of embeddings and
+  is exposed only by explicit raw expansion or grep.
 - Chunk texts ARE sent to your configured embedding/rerank provider (Voyage by
   default) — pick a provider you trust with your transcripts, or point the
   OpenAI-compatible provider at a local endpoint.

--- a/agents/recall.md
+++ b/agents/recall.md
@@ -1,24 +1,29 @@
 ---
 name: recall
-description: Use to get instantly grounded in a task, bug, feature, or decision that may have been worked on in a PREVIOUS Claude Code session. Dispatch with the topic; it searches the session history deeply (semantic + keyword + drill-down), reads the raw turns itself, and returns ONLY a tight brief — keeping the main thread's context clean. Prefer over calling recall_search directly when you need the full arc of a past task, not just a snippet.
+description: Use to get grounded in a task, bug, feature, or decision from a PREVIOUS Claude Code or Codex session. Dispatch with the topic; it searches the unified history deeply (semantic + keyword + drill-down), reads the raw turns itself, and returns ONLY a tight brief — keeping the main thread's context clean. Prefer when you need the full arc of a past task, not just a snippet.
 model: sonnet
 tools: mcp__plugin_session-recall_session-recall__recall_search, mcp__plugin_session-recall_session-recall__expand_around, mcp__plugin_session-recall_session-recall__step, mcp__plugin_session-recall_session-recall__grep, mcp__plugin_session-recall_session-recall__recent_sessions, mcp__session-recall__recall_search, mcp__session-recall__expand_around, mcp__session-recall__step, mcp__session-recall__grep, mcp__session-recall__recent_sessions, Read
 ---
 
 You are a session-history retrieval specialist. Given a task/topic, dig through the user's
-past Claude Code sessions and return a tight, decision-focused brief — nothing else. You burn
-YOUR context on the raw retrieval so the main thread stays clean.
+past Claude Code and Codex sessions and return a tight, decision-focused brief — nothing else.
+You burn YOUR context on the raw retrieval so the main thread stays clean. Results come from one
+index and carry `source=claude|codex`; preserve that provenance in the brief. Primary user/agent
+sessions are indexed, while spawned subagent sidechains are intentionally skipped.
 
 ## How to search (be thorough — it is cheap for you)
 Ground the brief in these recall tools over the raw transcripts — that is the point; do not
 reconstruct from git logs or memory files when the recall tools can answer.
 0. If the topic is "what's the latest / current state", `recent_sessions(scope_cwd=<cwd>)` lists
    the freshest sessions first (turn counts + first-prompt labels) to orient before drilling in.
+   Pass `source="claude"` or `source="codex"` only when the request names a host; otherwise search
+   both sources, including active and archived Codex sessions.
 1. `recall_search(<topic>)` — semantic search. Try 2-3 phrasings if the first is thin; the
    user re-describes tasks loosely. If your dispatch names a current working directory / project,
    pass it as `scope_cwd` (works on `grep` too) to scope results to that repo — worktrees collapse
    to the repo root. Omit it, or retry without it, for cross-project history or when scoped results
-   come back thin.
+   come back thin. Preserve the requested `source` filter across search, expansion, stepping,
+   recent, and grep calls.
 2. Hits are ranked snippets that may span several sessions AND several *different* sub-issues.
    Work out which hits belong to the SAME task vs adjacent ones.
 3. For the best 1-3 hits, `expand_around(session_id, uuid)` to read the surrounding arc
@@ -31,7 +36,7 @@ reconstruct from git logs or memory files when the recall tools can answer.
 - **Key decisions + WHY:** the choices and their reasoning — the highest-value part.
 - **Tried / rejected:** approaches abandoned, and why.
 - **Current state:** where it landed / what shipped / what is still open.
-- **Pointers:** session_id + uuid anchors for the defining turns, so the main thread can drill in.
+- **Pointers:** source + session_id + uuid anchors for the defining turns, so the main thread can drill in.
 
 Rules:
 - Return ONLY the brief. Never dump raw turns, snippets, tool output, or your search steps.

--- a/commands/recall.md
+++ b/commands/recall.md
@@ -1,11 +1,15 @@
 ---
-description: Recall past Claude Code sessions about a topic — dispatches the deep-recall agent and returns a brief.
+description: Recall past Claude Code and Codex sessions about a topic and return a decision-focused brief.
 ---
 
-Dispatch the `recall` subagent (Agent tool, `subagent_type: session-recall:recall`) with the
-topic: "$ARGUMENTS".
+Recall the topic: "$ARGUMENTS" from the unified Claude Code + Codex session index.
 
-The agent searches past session history deeply and returns a tight brief (task, key decisions
-and why, what was tried/rejected, current state, and anchor pointers). Relay that brief.
+If the host exposes the dedicated `recall` subagent, dispatch it (in Claude Code:
+`subagent_type: session-recall:recall`). Otherwise search iteratively with `recent_sessions`,
+`recall_search`, `expand_around`/`step`, and `grep`.
+
+Use a requested `claude` or `codex` source filter; otherwise search both. Return only a tight brief:
+task, key decisions and why, tried/rejected approaches, current state, and
+`source` + `session_id` + `uuid` pointers.
 
 If "$ARGUMENTS" is empty, ask the user what to recall.

--- a/docs/decisions/2026-07-10-unified-claude-codex-index.md
+++ b/docs/decisions/2026-07-10-unified-claude-codex-index.md
@@ -1,0 +1,46 @@
+# Unified Claude Code + Codex index
+
+## Decision
+
+Use one SQLite/vector index for both transcript producers, with explicit
+`source = claude|codex` provenance on chunks and indexed files.
+
+Codex discovery covers both active `CODEX_HOME/sessions/**/*.jsonl` rollouts
+and `CODEX_HOME/archived_sessions/**/*.jsonl`. Spawned subagent rollouts are
+skipped from the first `session_meta` marker (`thread_source`,
+`source.subagent`, or `agent_path`) because they copy parent history and are
+under-the-hood execution, matching the existing Claude sidechain policy.
+
+## Extraction boundary
+
+- Claude keeps its existing v2 extractor and signature, avoiding a costly
+  re-embed of unchanged history.
+- Codex has an independent `codex-v1` extractor signature.
+- Codex `event_msg/user_message` and `event_msg/agent_message` records are the
+  canonical embedded surface. `response_item` messages are deliberately kept
+  out of embeddings because real rollouts can contain service instructions
+  shaped like user text. They, tools, and reasoning remain available only
+  through explicit navigation/grep.
+- Codex records have no Claude-style UUID, so anchors use the stable opaque
+  cursor `codex:<thread-id>:<byte-offset>`.
+
+## Retrieval boundary
+
+Production indexing and retrieval are streaming. `grep` scans line by line;
+its result set is capped (100 by default), and
+`expand_around` and `step` retain only a bounded deque around the requested
+cursor. This is required because individual local Codex rollouts can be
+hundreds of megabytes. Human-readable expansion and grep exclude encrypted
+reasoning fields.
+
+Codex archive moves reuse embeddings by `(source, session_id, content_hash)`.
+Deleted-path pruning happens only after a successful replacement; a provider
+failure therefore leaves the last good memory available for the next retry.
+
+## Compatibility
+
+Existing databases migrate in place: old chunks and indexed-file markers
+default to `source = claude`. The original Python and MCP arguments remain
+valid; `source` is additive and optional. Pre-fingerprint Claude signatures
+are migrated in place to the current embedding-space signature, so installing
+Codex support does not by itself re-embed the Claude corpus.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,9 +6,8 @@
         "hooks": [
           {
             "type": "command",
-            "async": true,
             "timeout": 10,
-            "command": "pgrep -f 'session-recall index' >/dev/null 2>&1 || { command -v session-recall >/dev/null 2>&1 && (session-recall index >/tmp/session-recall-index.log 2>&1 &) || echo 'session-recall: CLI not on PATH - index not refreshed (see README: Keeping the index fresh)' >>/tmp/session-recall-index.log; }"
+            "command": "export PATH=\"$HOME/.local/bin:$HOME/bin:$PATH\"; sr=session-recall; pgrep -f \"$sr index\" >/dev/null 2>&1 || { command -v \"$sr\" >/dev/null 2>&1 && (\"$sr\" index >/tmp/session-recall-index.log 2>&1 &) || echo 'session-recall: CLI not on PATH - index not refreshed (see README: Keeping the index fresh)' >>/tmp/session-recall-index.log; }"
           }
         ]
       }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "session-recall"
-version = "0.2.0"
+version = "0.3.0"
 requires-python = ">=3.11"
 dependencies = [
     "sqlite-vec==0.1.9",

--- a/skills/session-recall/SKILL.md
+++ b/skills/session-recall/SKILL.md
@@ -1,40 +1,34 @@
 ---
 name: session-recall
-description: Use at the START of a task when the user references a bug, feature, decision, file, or piece of work you may have discussed or built together in a PAST session — before assuming you have fresh context. Searches prior Claude Code session history so you resume with the real prior context instead of starting cold. Triggers include "remember when…", "we worked on…", "the X bug", "back to…", "what did we decide about…", or any task that plausibly has history.
+description: Search the unified local history of past Claude Code and Codex sessions at the START of a task when the user references a prior bug, feature, decision, file, or piece of work. Use before assuming fresh context for prompts such as "remember when…", "we worked on…", "the X bug", "back to…", "what did we decide about…", or any task that plausibly has history.
 ---
 
 # Session Recall
 
-You have a searchable memory of past Claude Code sessions. Use it so the user does not have to
-re-explain things you already worked through together.
+Use the shared Claude Code + Codex index so the user does not have to re-explain prior work.
+Treat each result's `source` (`claude` or `codex`) as provenance, not relevance.
 
-## When to use
-At the start of a task that plausibly has prior history — the user references past work, a named
-bug/feature, a prior decision, or a file you may have touched before. When the task feels
-familiar, check; it is cheap.
+## Recall workflow
 
-Do NOT use for brand-new tasks with no plausible history, or trivial one-offs.
+1. Start with `recall_search`; use `recent_sessions` first when the request is about the latest
+   state or index freshness.
+2. Pass `scope_cwd` for repo-local questions. Omit it for cross-project recall; retry globally if
+   a scoped search is thin.
+3. Pass `source="claude"` or `source="codex"` only when the user names a host or provenance
+   matters. Omit `source` to search the unified history; preserve it through expansion and
+   stepping when one is selected.
+4. For deeper grounding, inspect the best anchors with `expand_around`, walk with `step`, and use
+   `grep` for exact identifiers that semantic search misses.
 
-## Two ways to recall (pick by depth)
-- **Quick check** — call the `recall_search` tool yourself (from the session-recall MCP server).
-  Good for "did we ever discuss X?": ranked snippets in one call. The `recent_sessions` tool lists
-  the freshest past sessions when you want "what's the latest / how current is the index".
-- **Deep grounding** — dispatch the **`recall` subagent** (Agent tool,
-  `subagent_type: session-recall:recall`) with the topic. It searches deeply, reads the raw arc
-  itself, and returns ONLY a tight brief (task / decisions+why / tried-rejected / current state /
-  pointers) — keeping YOUR context clean. Use this to genuinely resume a task, not just find a
-  snippet.
+## Deep-recall execution
 
-## Scoping to the current project
-`recall_search`, `grep` and `recent_sessions` take an optional `scope_cwd`. Pass your current working directory to
-restrict results to the current project/repo — worktrees collapse to the repo root automatically,
-so the main checkout and every worktree share one scope. This cuts cross-project noise and sharpens
-the top hits; make it your default for repo-local questions.
-- **Quick check:** call `recall_search("<topic>", scope_cwd="<your cwd>")`.
-- **Deep grounding:** the `recall` subagent has no shell, so include your current working directory
-  in the dispatch prompt and tell it to scope to that repo.
-- **Omit `scope_cwd`** when you WANT cross-project recall ("how did I solve this in another repo").
-  If a scoped search returns little or nothing, retry without it for a global search.
+- If the current host exposes a dedicated recall subagent, dispatch it with the topic, current
+  working directory, and any requested source filter. In Claude Code this may be
+  `session-recall:recall`.
+- If the host does not expose that subagent, perform the same deep search directly and
+  iteratively with the MCP tools. Never require a Claude-only subagent from Codex or another host.
+- Return a tight brief: task, key decisions and why, tried/rejected approaches, current state, and
+  `source` + `session_id` + `uuid` pointers.
 
 ## After recalling
 - Ground your response in what you find; cite the prior decision and its WHY when relevant.

--- a/src/session_recall/cli.py
+++ b/src/session_recall/cli.py
@@ -10,41 +10,59 @@ from .retrieve import Recall
 def main(argv=None):
     parser = argparse.ArgumentParser(prog="session-recall")
     sub = parser.add_subparsers(dest="cmd", required=True)
-    sub.add_parser("index")
+    ip = sub.add_parser("index")
+    ip.add_argument("--source", choices=("all", "claude", "codex"), default="all")
     sp = sub.add_parser("search")
     sp.add_argument("query")
     sp.add_argument("-k", type=int, default=10)
     sp.add_argument("--scope", help="cwd to scope results to (repo root)")
+    sp.add_argument("--source", choices=("claude", "codex"))
     rp = sub.add_parser("recent")
     rp.add_argument("--scope")
     rp.add_argument("-n", type=int, default=10)
+    rp.add_argument("--source", choices=("claude", "codex"))
     gp = sub.add_parser("grep")
     gp.add_argument("pattern")
     gp.add_argument("--scope")
     gp.add_argument("--session")
-    sub.add_parser("prune")  # drop index rows for transcripts deleted from disk
+    gp.add_argument("--source", choices=("claude", "codex"))
+    gp.add_argument("--limit", type=int, default=100)
+    pp = sub.add_parser("prune")  # drop rows for transcripts deleted from disk
+    pp.add_argument("--source", choices=("claude", "codex"))
     args = parser.parse_args(argv)
 
     store = Store(config.DB_PATH)
     if args.cmd == "index":
-        n = index_corpus(store, make_embedder(), config.CLAUDE_PROJECTS)
-        print(f"indexed {n} new chunks")
+        claude_root = config.CLAUDE_PROJECTS if args.source in {"all", "claude"} else None
+        codex_roots = ((config.CODEX_SESSIONS, config.CODEX_ARCHIVED_SESSIONS)
+                       if args.source in {"all", "codex"} else ())
+        n = index_corpus(
+            store,
+            make_embedder(),
+            claude_root,
+            codex_dirs=codex_roots,
+        )
+        print(f"indexed {n} chunks from changed transcripts")
     elif args.cmd == "search":
         recall = Recall(store, make_embedder(), make_reranker())
-        for a in recall.recall_search(args.query, k=args.k, scope_cwd=args.scope):
+        for a in recall.recall_search(
+                args.query, k=args.k, scope_cwd=args.scope, source=args.source):
             score = f"{a.score:.3f}" if a.score is not None else "fts"
-            print(f"[{score}] {a.project} {a.session_id} {a.role}: {a.snippet}")
+            print(f"[{score}] {a.source} {a.project} {a.session_id} {a.role}: {a.snippet}")
     elif args.cmd == "recent":
         recall = Recall(store, make_embedder(), make_reranker())
-        for s in recall.recent_sessions(scope_cwd=args.scope, limit=args.n):
-            print(f"{s['session_id']} {s['project']} {s['turns']}t "
+        for s in recall.recent_sessions(
+                scope_cwd=args.scope, limit=args.n, source=args.source):
+            print(f"{s['source']} {s['session_id']} {s['project']} {s['turns']}t "
                   f"{s['last_activity_human']} {s['label']}")
     elif args.cmd == "grep":
         recall = Recall(store, make_embedder(), make_reranker())
-        for a in recall.grep(args.pattern, session_id=args.session, scope_cwd=args.scope):
-            print(f"{a.session_id} {a.uuid} [{a.role}] {a.snippet}")
+        for a in recall.grep(
+                args.pattern, session_id=args.session, scope_cwd=args.scope,
+                source=args.source, limit=args.limit):
+            print(f"{a.source} {a.session_id} {a.uuid} [{a.role}] {a.snippet}")
     elif args.cmd == "prune":
-        print(f"pruned {store.prune_deleted()} deleted transcript(s)")
+        print(f"pruned {store.prune_deleted(source=args.source)} deleted transcript(s)")
     store.close()
 
 

--- a/src/session_recall/config.py
+++ b/src/session_recall/config.py
@@ -3,7 +3,15 @@ from pathlib import Path
 
 DATA_DIR = Path(os.environ.get("XDG_DATA_HOME") or (Path.home() / ".local" / "share")) / "session-recall"
 DB_PATH = DATA_DIR / "index.db"
-CLAUDE_PROJECTS = Path.home() / ".claude" / "projects"
+CLAUDE_PROJECTS = Path(
+    os.environ.get("SESSION_RECALL_CLAUDE_PROJECTS")
+    or (Path.home() / ".claude" / "projects")
+).expanduser()
+CODEX_HOME = Path(
+    os.environ.get("CODEX_HOME") or (Path.home() / ".codex")
+).expanduser()
+CODEX_SESSIONS = CODEX_HOME / "sessions"
+CODEX_ARCHIVED_SESSIONS = CODEX_HOME / "archived_sessions"
 
 # Embedding provider — PLUGGABLE. Voyage is the default (and the author's preference),
 # but any provider works: set these env vars (e.g. provider=openai,

--- a/src/session_recall/extract.py
+++ b/src/session_recall/extract.py
@@ -1,13 +1,20 @@
 import hashlib
-import json
 import re
-from datetime import datetime
 from .models import Chunk
 from .scope import project_label
+from .transcripts import (
+    TranscriptEvent,
+    extract_codex_file,
+    extractor_version,
+    iter_transcript_events,
+)
 
 # Bump when extraction logic changes -> baked into the per-file index signature so
 # stale files are re-extracted on the next index run. v2 = harness-boilerplate filter.
 EXTRACTOR_VERSION = 2
+# Codex has an independent extraction contract.  Keeping a separate tag means
+# adding/changing Codex support never invalidates (and re-embeds) an unchanged
+# Claude corpus.
 
 # Claude Code injects machine text into user turns (notifications, reminders, slash-command
 # echoes, local-command output). It is NOT the user speaking, so it must not be embedded as
@@ -39,61 +46,66 @@ def _clean_user_text(content: str) -> str | None:
     cleaned = cleaned.strip()
     return cleaned or None
 
-def _ts(obj) -> int:
-    s = obj.get("timestamp")
-    if not s:
-        return 0
-    try:
-        return int(datetime.fromisoformat(s.replace("Z", "+00:00")).timestamp())
-    except ValueError:
-        return 0
+def extractor_tag(source: str) -> str:
+    version = extractor_version(source)
+    return f"v{version}" if source == "claude" else f"codex-v{version}"
 
-def _mk(obj, project, role, text, offset, length, turn_index) -> Chunk:
-    cwd = obj.get("cwd", "")
+
+def _mk(event: TranscriptEvent, project: str, role: str, text: str) -> Chunk:
     return Chunk(
-        session_id=obj.get("sessionId", ""),
-        uuid=obj.get("uuid", ""),
+        session_id=event.session_id,
+        uuid=event.uuid,
         role=role,
         text=text,
-        project=project_label(cwd) or project,
-        cwd=cwd,
-        git_branch=obj.get("gitBranch", ""),
-        ts=_ts(obj),
-        file_path="",  # filled by caller-aware path below
-        byte_offset=offset,
-        byte_len=length,
-        turn_index=turn_index,
+        project=project_label(event.cwd) or project,
+        cwd=event.cwd,
+        git_branch=event.git_branch,
+        ts=event.ts,
+        file_path="",  # filled by extract_file
+        byte_offset=event.byte_offset,
+        byte_len=event.byte_len,
+        turn_index=event.turn_index,
         content_hash=hashlib.sha256(text.encode("utf-8")).hexdigest(),
+        source=event.source,
     )
 
-def extract_file(path: str, project: str) -> list[Chunk]:
+
+def _extract_claude(path: str, project: str) -> list[Chunk]:
     chunks: list[Chunk] = []
-    offset = 0
-    with open(path, "rb") as f:
-        for turn_index, raw in enumerate(f):
-            length = len(raw)
-            line_offset = offset
-            offset += length
-            try:
-                obj = json.loads(raw)
-            except json.JSONDecodeError:
-                continue
-            t = obj.get("type")
-            msg = obj.get("message") or {}
-            if t == "user" and isinstance(msg.get("content"), str):
-                text = _clean_user_text(msg["content"])
-                if text is None:
-                    continue  # pure harness boilerplate — not the user speaking
-                c = _mk(obj, project, "user", text, line_offset, length, turn_index)
-                c.file_path = path
-                chunks.append(c)
-            elif t == "assistant" and isinstance(msg.get("content"), list):
-                for block in msg["content"]:
-                    if isinstance(block, dict) and block.get("type") == "text":
-                        text = block.get("text", "")
-                        if not text.strip():
-                            continue
-                        c = _mk(obj, project, "assistant", text, line_offset, length, turn_index)
-                        c.file_path = path
-                        chunks.append(c)
+    for event in iter_transcript_events(path, source="claude"):
+        obj = event.obj
+        msg = obj.get("message") or {}
+        if obj.get("type") == "user" and isinstance(msg.get("content"), str):
+            text = _clean_user_text(msg["content"])
+            if text is None:
+                continue  # pure harness boilerplate — not the user speaking
+            chunk = _mk(event, project, "user", text)
+            chunk.file_path = path
+            chunks.append(chunk)
+        elif obj.get("type") == "assistant" and isinstance(msg.get("content"), list):
+            for block in msg["content"]:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    text = block.get("text", "")
+                    if not text.strip():
+                        continue
+                    chunk = _mk(event, project, "assistant", text)
+                    chunk.file_path = path
+                    chunks.append(chunk)
     return chunks
+
+
+def _extract_codex(path: str, project: str) -> list[Chunk]:
+    """Extract one copy of the visible Codex conversation surface.
+
+    event_msg is the canonical clean surface. response_item messages, reasoning,
+    and tools remain reachable through grep/expand but are never embedded.
+    """
+    return extract_codex_file(path, project=project)
+
+
+def extract_file(path: str, project: str, source: str = "claude") -> list[Chunk]:
+    if source == "claude":
+        return _extract_claude(path, project)
+    if source == "codex":
+        return _extract_codex(path, project)
+    raise ValueError(f"unknown transcript source: {source!r}")

--- a/src/session_recall/index.py
+++ b/src/session_recall/index.py
@@ -1,9 +1,12 @@
 import sys
 from pathlib import Path
+from collections.abc import Iterable
 from . import config
-from .extract import extract_file, EXTRACTOR_VERSION
+from .extract import extract_file, extractor_tag
 from .store import Store
 from .embed import Embedder
+from .scope import project_label
+from .transcripts import codex_file_header
 
 def _embed_fp() -> str:
     # Which embedding space the vectors live in. Same-dim provider/model swaps
@@ -11,86 +14,172 @@ def _embed_fp() -> str:
     # cache. WHY: docs/decisions/2026-07-02-post-review-hardening.md
     return f"{config.EMBED_PROVIDER}/{config.EMBED_MODEL}/{config.EMBED_DIM}"
 
-def _file_sig(path: Path) -> str:
+def _file_sig(path: Path, source: str = "claude") -> str:
     st = path.stat()
     # Extractor version and embed fingerprint are part of the signature: bumping
     # either invalidates every file, so a changed extractor OR embedding model
     # triggers a clean re-extract/re-embed on the next run.
-    return f"v{EXTRACTOR_VERSION}:{_embed_fp()}:{int(st.st_mtime)}:{st.st_size}"
+    prefix = f"{extractor_tag(source)}:{_embed_fp()}"
+    if source == "codex":
+        # Codex rollouts can move into the archive or be replaced. inode makes
+        # same-size/same-second replacements visible; path moves still reuse
+        # vectors by stable session id.
+        return f"{prefix}:{st.st_ino}:{int(st.st_mtime)}:{st.st_size}"
+    # Preserve the established Claude signature so this upgrade does not
+    # invalidate and re-embed the existing corpus.
+    return f"{prefix}:{int(st.st_mtime)}:{st.st_size}"
 
 def _project_name(project_dir: Path) -> str:
     # "-Users-me-proj" -> "proj" (last path segment of the decoded dir)
     return project_dir.name.lstrip("-").split("-")[-1]
 
-def index_corpus(store: Store, embedder: Embedder, projects_dir: Path) -> int:
-    # Drop rows for transcripts deleted since the last run before scanning: a
-    # deleted file is never visited below (we only walk existing files), so its
-    # chunks would otherwise linger in the index forever.
-    store.prune_deleted()
+def _claude_files(projects_dir: Path | None):
+    if projects_dir is None or not Path(projects_dir).is_dir():
+        return
+    for project_dir in sorted(Path(projects_dir).iterdir()):
+        if not project_dir.is_dir():
+            continue
+        project = _project_name(project_dir)
+        # Non-recursive on purpose: nested files are Claude subagent sidechains.
+        for jsonl in sorted(project_dir.glob("*.jsonl")):
+            yield jsonl, "claude", project
+
+
+def _codex_files(codex_dirs: Iterable[Path]):
+    seen: set[str] = set()
+    for root in codex_dirs:
+        root = Path(root)
+        if not root.is_dir():
+            continue
+        # Active sessions are nested YYYY/MM/DD; archives are currently flat.
+        # rglob covers both layouts and future-proofs archive organization.
+        for jsonl in sorted(root.rglob("*.jsonl")):
+            key = str(jsonl)
+            if key in seen:
+                continue
+            seen.add(key)
+            yield jsonl, "codex", ""
+
+
+def _forget_file(store: Store, path: str):
+    """Remove a file that is now recognized as an under-the-hood sidechain."""
+    store.delete_file(path)
+    store.db.execute("DELETE FROM indexed_files WHERE path = ?", (path,))
+    store.commit()
+
+
+def _roots_safe_to_prune(store: Store, roots: Iterable[Path], source: str) -> bool:
+    """Do not mistake an unavailable transcript root for mass deletion.
+
+    A root that has never existed is harmless (for example Codex may not have
+    created ``archived_sessions`` yet). A missing root that still owns indexed
+    paths is treated as temporarily unavailable, so its last good rows remain.
+    """
+    indexed = [Path(row[0]).expanduser().absolute() for row in store.db.execute(
+        "SELECT path FROM indexed_files WHERE source = ?", (source,)
+    ).fetchall()]
+    return all(
+        Path(root).expanduser().absolute().is_dir()
+        or not any(
+            path.is_relative_to(Path(root).expanduser().absolute())
+            for path in indexed
+        )
+        for root in roots
+    )
+
+
+def index_corpus(store: Store, embedder: Embedder, projects_dir: Path | None,
+                 codex_dirs: Iterable[Path] | None = None) -> int:
+    """Incrementally index Claude Code plus optional Codex transcript roots.
+
+    The fourth argument is optional to preserve the original Claude-only Python
+    API.  The CLI passes both Codex active and archive roots by default.
+    """
+    codex_roots = tuple(codex_dirs or ())
+    selected_sources: set[str] = set()
+    prunable_sources: set[str] = set()
+    if projects_dir is not None:
+        selected_sources.add("claude")
+        if Path(projects_dir).is_dir():
+            prunable_sources.add("claude")
+    if codex_roots:
+        selected_sources.add("codex")
+        if _roots_safe_to_prune(store, codex_roots, "codex"):
+            prunable_sources.add("codex")
     # Grandfather pre-fingerprint sigs (v{N}:mtime:size — exactly 3 parts): their
     # vectors were produced by the then-configured provider, so stamping the
     # CURRENT fingerprint keeps them valid without a wholesale re-embed of the
     # corpus. A real provider change after this upgrade still mismatches the sig.
-    for path, sig in store.db.execute("SELECT path, sig FROM indexed_files").fetchall():
+    for path, sig, source in store.db.execute(
+            "SELECT path, sig, source FROM indexed_files").fetchall():
+        if source not in selected_sources:
+            continue
         parts = sig.split(":")
-        if len(parts) == 3:
+        if len(parts) == 3 and parts[0].startswith("v") and parts[0][1:].isdigit():
             store.db.execute("UPDATE indexed_files SET sig = ? WHERE path = ?",
                              (f"{parts[0]}:{_embed_fp()}:{parts[1]}:{parts[2]}", path))
     store.commit()
     new_count = 0
     failed: list[str] = []
-    for project_dir in sorted(Path(projects_dir).iterdir()):
-        if not project_dir.is_dir():
-            continue
-        project = _project_name(project_dir)
-        # Non-recursive on purpose: the flat *.jsonl files ARE the real
-        # conversation transcripts. Subagent sidechains live one level down in
-        # <session>/subagents/agent-*.jsonl and are intentionally skipped — they
-        # are under-the-hood tool/agent internals, not user<->assistant turns,
-        # so indexing them would add noise (and ~8x cost) for no recall gain.
-        # Switch to rglob only if subagent recall becomes an explicit goal.
-        for jsonl in sorted(project_dir.glob("*.jsonl")):
-            # One transaction per file: delete + re-add + mark commit together, so
-            # a failure mid-file (embedding API down, broken transcript) rolls back
-            # to the previous good state — never a half-indexed hole. And one bad
-            # file must not abort the run: log it, retry on the next run (its sig
-            # stays unmarked), keep indexing the rest. _file_sig stats the path, so
-            # it belongs INSIDE the isolation (broken symlink, delete race).
-            try:
-                sig = _file_sig(jsonl)
-                if store.is_indexed(str(jsonl), sig):
+    failed_sources: set[str] = set()
+    jobs = list(_claude_files(projects_dir) or ())
+    jobs.extend(_codex_files(codex_roots))
+    for jsonl, source, project in jobs:
+        # One transaction per file: delete + re-add + marker commit together.
+        # _file_sig and header reads stay INSIDE this isolation for delete races,
+        # broken symlinks, or partially-written live rollouts.
+        try:
+            if source == "codex":
+                meta = codex_file_header(jsonl)
+                if meta.is_sidechain:
+                    _forget_file(store, str(jsonl))
                     continue
-                # Transcripts are append-only: reuse the vectors of unchanged chunks
-                # (matched by content_hash) and only embed genuinely new texts —
-                # otherwise every hook run re-embeds the whole live transcript.
-                # Reuse ONLY if the stored rows were embedded in the current space
-                # (their sig starts with the current version+fingerprint): checked
-                # per file, so even a crashed mid-upgrade run can never resurrect
-                # old-space blobs. WHY: docs/decisions/2026-07-02-post-review-hardening.md
-                stored = store.stored_sig(str(jsonl)) or ""
-                same_space = stored.startswith(f"v{EXTRACTOR_VERSION}:{_embed_fp()}:")
-                cached = store.embeddings_by_hash(str(jsonl)) if same_space else {}
-                # Changed file (or version bump): drop stale rows before re-adding so
-                # a growing transcript never accumulates duplicate chunks. No-op if new.
-                store.delete_file(str(jsonl))
-                chunks = extract_file(str(jsonl), project=project)
-                if chunks:
-                    new_texts = [c.text for c in chunks if c.content_hash not in cached]
-                    vecs = embedder.embed_documents(new_texts) if new_texts else []
-                    if len(vecs) != len(new_texts):
-                        # a bare StopIteration would log an empty cause line
-                        raise RuntimeError(
-                            f"embedder returned {len(vecs)} vectors for {len(new_texts)} texts")
-                    new_vecs = iter(vecs)
-                    for chunk in chunks:
-                        reused = cached.get(chunk.content_hash)
-                        store.add(chunk, reused if reused is not None else next(new_vecs))
-                store.mark_indexed(str(jsonl), sig)
-                store.commit()
-                new_count += len(chunks)
-            except Exception as e:
-                store.rollback()
-                failed.append(f"{jsonl}: {e}")
+                project = project_label(meta.cwd) or "codex"
+            sig = _file_sig(jsonl, source)
+            if store.is_indexed(str(jsonl), sig):
+                continue
+            # Reuse only vectors produced by the same source extractor version
+            # and embedding space. This makes live append-only updates cheap.
+            stored = store.stored_sig(str(jsonl)) or ""
+            sig_prefix = f"{extractor_tag(source)}:{_embed_fp()}:"
+            same_space = stored.startswith(sig_prefix)
+            cached = store.embeddings_by_hash(str(jsonl)) if same_space else {}
+            # Codex moves completed rollouts from sessions/ to
+            # archived_sessions/. Reuse the old path's vectors by stable thread
+            # id so archiving does not resend the whole conversation.
+            if source == "codex" and not stored and not cached:
+                cached = store.embeddings_by_session(
+                    meta.session_id, source="codex", sig_prefix=sig_prefix)
+            store.delete_file(str(jsonl))
+            chunks = extract_file(str(jsonl), project=project, source=source)
+            if chunks:
+                # A repeated prompt/reply needs one embedding even though every
+                # occurrence keeps its own provenance row.
+                missing: dict[str, str] = {}
+                for chunk in chunks:
+                    if chunk.content_hash not in cached:
+                        missing.setdefault(chunk.content_hash, chunk.text)
+                new_texts = list(missing.values())
+                vecs = embedder.embed_documents(new_texts) if new_texts else []
+                if len(vecs) != len(new_texts):
+                    raise RuntimeError(
+                        f"embedder returned {len(vecs)} vectors for {len(new_texts)} texts")
+                fresh = dict(zip(missing, vecs))
+                for chunk in chunks:
+                    reused = cached.get(chunk.content_hash)
+                    store.add(chunk, reused if reused is not None else fresh[chunk.content_hash])
+            store.mark_indexed(str(jsonl), sig, source=source)
+            store.commit()
+            new_count += len(chunks)
+        except Exception as e:
+            store.rollback()
+            failed.append(f"{jsonl}: {e}")
+            failed_sources.add(source)
+    # Prune after successful replacements. If an archive move fails to index,
+    # retaining the missing old path's rows is preferable to creating a recall
+    # hole; the next clean run reconciles it.
+    for source in sorted(prunable_sources - failed_sources):
+        store.prune_deleted(source=source)
     if failed:
         print(f"session-recall: {len(failed)} file(s) failed to index (will retry "
               f"next run):\n  " + "\n  ".join(failed[:10]), file=sys.stderr)

--- a/src/session_recall/models.py
+++ b/src/session_recall/models.py
@@ -15,6 +15,9 @@ class Chunk:
     byte_len: int
     turn_index: int
     content_hash: str
+    # Transcript producer. Kept last with a default so callers constructing
+    # synthetic/legacy chunks remain source-compatible.
+    source: str = "claude"
 
 @dataclass
 class Anchor:
@@ -27,6 +30,7 @@ class Anchor:
     score: "float | None"
     project: str
     when: int
+    source: str = "claude"
 
 @dataclass
 class Turn:
@@ -34,3 +38,4 @@ class Turn:
     type: str
     content: str
     raw: dict
+    source: str = "claude"

--- a/src/session_recall/retrieve.py
+++ b/src/session_recall/retrieve.py
@@ -1,30 +1,59 @@
 # src/session_recall/retrieve.py
 import json
 import time
-from pathlib import Path
+from collections import deque
 from .store import Store
 from .embed import Embedder
 from .rerank import Reranker
 from .models import Anchor, Turn
 from .scope import repo_root, in_scope, project_label
 from .timefmt import humanize_ts
+from .transcripts import (
+    TranscriptEvent,
+    is_navigable,
+    iter_transcript_events,
+    sanitize_raw,
+)
 
 def _snippet(text: str, n: int = 200) -> str:
     return text[:n] + ("…" if len(text) > n else "")
+
+
+def _match_snippet(text: str, pattern: str, n: int = 240) -> str:
+    """Return a bounded grep snippet centered near the actual match."""
+    index = text.find(pattern)
+    if index < 0:
+        return _snippet(text, n)
+    start = max(0, index - n // 3)
+    end = min(len(text), start + n)
+    return ("…" if start else "") + text[start:end] + ("…" if end < len(text) else "")
 
 class Recall:
     def __init__(self, store: Store, embedder: Embedder, reranker: "Reranker | None" = None):
         self.store = store
         self.embedder = embedder
         self.reranker = reranker
+        # Raw-only grep anchors have no chunks row. Keep an in-process hint so
+        # the normal grep -> expand/step flow resolves without rescanning the
+        # corpus; a streaming fallback below covers process restarts.
+        self._anchor_files: dict[tuple[str, str, str], str] = {}
+
+    @staticmethod
+    def _validate_source(source: str | None) -> None:
+        if source not in {None, "claude", "codex"}:
+            raise ValueError(
+                f"source must be 'claude', 'codex', or omitted; got {source!r}")
 
     @staticmethod
     def _anchor(c, score: "float | None") -> Anchor:
         return Anchor(session_id=c.session_id, uuid=c.uuid, role=c.role,
-                      snippet=_snippet(c.text), score=score, project=c.project, when=c.ts)
+                      snippet=_snippet(c.text), score=score, project=c.project,
+                      when=c.ts, source=c.source)
 
     def recall_search(self, query: str, k: int = 10, candidates: int = 100,
-                      scope_cwd: str | None = None) -> list[Anchor]:
+                      scope_cwd: str | None = None,
+                      source: str | None = None) -> list[Anchor]:
+        self._validate_source(source)
         # scope_cwd is the agent's raw cwd; normalize to a repo root so the main
         # checkout and every worktree under it collapse to one scope. None = global.
         root = repo_root(scope_cwd) if scope_cwd else None
@@ -32,12 +61,14 @@ class Recall:
         dist: dict[int, float | None] = {}
         try:
             qv = self.embedder.embed_query(query)
-            for cid, d in self.store.knn(qv, candidates, scope_root=root):
+            for cid, d in self.store.knn(
+                    qv, candidates, scope_root=root, source=source):
                 order.append(cid)
                 dist[cid] = d
         except Exception:
             pass  # embedding unavailable -> FTS-only
-        for cid in self.store.fts(query, candidates, scope_root=root):
+        for cid in self.store.fts(
+                query, candidates, scope_root=root, source=source):
             if cid not in dist:
                 order.append(cid)
                 dist[cid] = None  # keyword match, no vector distance
@@ -80,170 +111,220 @@ class Recall:
             out.append(self._anchor(chunk_by_id[cid], score))
         return out
 
-    def _read_turns(self, file_path: str) -> list[dict]:
-        turns: list[dict] = []
-        try:
-            with open(file_path, "rb") as f:
-                for raw in f:
-                    try:
-                        turns.append(json.loads(raw))
-                    except json.JSONDecodeError:
-                        continue
-        except OSError:
-            # The transcript was deleted/moved/made-unreadable since indexing. A
-            # global grep touches EVERY indexed path, so one vanished file must not
-            # abort the whole scan; expand_around/step degrade to [] (consistent
-            # with their existing uuid-not-found path). WHY:
-            # docs/decisions/2026-06-27-grep-resilient-to-deleted-transcripts.md
-            return []
-        return turns
-
-    def _files_for(self, uuid: str, session_id: str | None) -> list[str]:
+    def _files_for(self, uuid: str, session_id: str | None,
+                   source: str | None = None) -> list[str]:
         """Transcript path candidates for an anchor. A uuid straight from
         recall_search resolves via chunks; grep anchors may point at raw turns
         that never became chunks (tool_result-only turns, filtered boilerplate),
         so fall back to the anchor's session: its chunk-bearing files, else the
         <session_id>.jsonl transcript itself (indexed but chunk-less)."""
-        files = [r[0] for r in self.store.db.execute(
-            "SELECT DISTINCT file_path FROM chunks WHERE uuid = ?", (uuid,)).fetchall()]
-        if not files and session_id:
-            files = [r[0] for r in self.store.db.execute(
-                "SELECT DISTINCT file_path FROM chunks WHERE session_id = ?",
-                (session_id,)).fetchall()]
+        self._validate_source(source)
+        files: list[str] = []
+        exact_files: set[str] = set()
+        for hinted_source in ((source,) if source else ("claude", "codex")):
+            hinted = self._anchor_files.get((hinted_source, session_id or "", uuid))
+            if hinted and hinted not in files:
+                files.append(hinted)
+                exact_files.add(hinted)
+
+        source_sql = " AND source = ?" if source else ""
+        uuid_params = (uuid, source) if source else (uuid,)
+        uuid_files = [r[0] for r in self.store.db.execute(
+            f"SELECT DISTINCT file_path FROM chunks WHERE uuid = ?{source_sql}",
+            uuid_params).fetchall()]
+        exact_files.update(uuid_files)
+        files += [path for path in uuid_files if path not in files]
+        if session_id:
+            sid_params = (session_id, source) if source else (session_id,)
+            files += [r[0] for r in self.store.db.execute(
+                f"SELECT DISTINCT file_path FROM chunks WHERE session_id = ?{source_sql}",
+                sid_params).fetchall() if r[0] not in files]
             escaped = (session_id.replace("\\", "\\\\")
                        .replace("_", "\\_").replace("%", "\\%"))
+            indexed_source_sql = " AND source = ?" if source else ""
+            indexed_params = ("%" + escaped + ".jsonl", source) if source else (
+                "%" + escaped + ".jsonl",)
             files += [r[0] for r in self.store.db.execute(
-                "SELECT path FROM indexed_files WHERE path LIKE ? ESCAPE '\\'",
-                ("%/" + escaped + ".jsonl",)).fetchall() if r[0] not in files]
+                f"SELECT path FROM indexed_files WHERE path LIKE ? ESCAPE '\\'"
+                f"{indexed_source_sql}", indexed_params).fetchall() if r[0] not in files]
+        if files and not exact_files:
+            # A resumed/mixed Claude transcript can carry a raw-only secondary
+            # session while another file owns that session's surface chunks.
+            # Try the cheap session/filename guesses first, then let _window
+            # stream the remaining indexed files until the exact pair is found.
+            indexed_source_sql = " WHERE source = ?" if source else ""
+            indexed_params = (source,) if source else ()
+            files += [row[0] for row in self.store.db.execute(
+                f"SELECT path FROM indexed_files{indexed_source_sql}",
+                indexed_params,
+            ).fetchall() if row[0] not in files]
+        if not files and session_id:
+            # Compatibility fallback for a raw-only secondary Claude session
+            # inside a mixed transcript whose filename belongs to another
+            # session. Stream until the exact opaque uuid is found.
+            indexed_source_sql = " WHERE source = ?" if source else ""
+            indexed_params = (source,) if source else ()
+            for path, path_source in self.store.db.execute(
+                    f"SELECT path, source FROM indexed_files{indexed_source_sql}",
+                    indexed_params).fetchall():
+                try:
+                    for event in iter_transcript_events(path, source=path_source):
+                        if event.uuid == uuid and event.session_id == session_id:
+                            files.append(path)
+                            self._anchor_files[(path_source, session_id, uuid)] = path
+                            break
+                except OSError:
+                    continue
+                if files:
+                    break
         if not files:
             raise LookupError(
                 f"no indexed transcript for uuid={uuid!r} session_id={session_id!r} "
                 f"(is the index fresh? run `session-recall index`)")
         return files
 
-    def _locate(self, session_id: str, uuid: str) -> tuple[list[dict], int] | None:
-        """Find the turn: (all turns of its transcript, its position), or None."""
-        for path in self._files_for(uuid, session_id):
-            objs = self._read_turns(path)
-            idx = next((i for i, o in enumerate(objs) if o.get("uuid") == uuid), None)
-            if idx is not None:
-                return objs, idx
-        return None
-
     @staticmethod
-    def _render_content(obj: dict) -> str:
-        """Human-readable content for a raw turn.
-
-        NEVER emits the encrypted thinking *signature* or the full message
-        envelope (usage/requestId/etc.) — those flooded the agent with kilobytes
-        of base64 and metadata, making drill-down useless. Assistant blocks are
-        flattened to readable text; tool calls/outputs are shown compactly.
-        """
-        msg = obj.get("message") or {}
-        content = msg.get("content")
-        if isinstance(content, str):
-            return content
-        if not isinstance(content, list):
-            return ""
-        parts: list[str] = []
-        for b in content:
-            if not isinstance(b, dict):
-                continue
-            bt = b.get("type")
-            if bt == "text":
-                parts.append(b.get("text", ""))
-            elif bt == "thinking":
-                th = (b.get("thinking") or "").strip()  # the TEXT, never b["signature"]
-                if th:
-                    parts.append(f"[thinking] {th}")
-            elif bt == "tool_use":
-                arg = json.dumps(b.get("input", {}), ensure_ascii=False)
-                parts.append(f"[tool_use:{b.get('name', '')}] {arg[:300]}")
-            elif bt == "tool_result":
-                rc = b.get("content")
-                rc = rc if isinstance(rc, str) else json.dumps(rc, ensure_ascii=False)
-                parts.append(f"[tool_result] {rc[:500]}")
-        return "\n".join(p for p in parts if p)
-
-    def _as_turn(self, obj: dict) -> Turn:
-        msg = obj.get("message") or {}
+    def _as_turn(event: TranscriptEvent) -> Turn:
+        """Render one normalized event without raw envelopes or encrypted fields."""
         return Turn(
-            role=msg.get("role", ""),
-            type=obj.get("type", ""),
-            content=self._render_content(obj),
-            raw={"uuid": obj.get("uuid", ""), "timestamp": obj.get("timestamp", "")},
+            role=event.role,
+            type=event.type,
+            content=event.content,
+            raw={"uuid": event.uuid, "timestamp": event.timestamp},
+            source=event.source,
         )
 
-    def expand_around(self, session_id: str, uuid: str, before: int = 2, after: int = 2) -> list[Turn]:
-        loc = self._locate(session_id, uuid)
-        if loc is None:
-            return []
-        objs, idx = loc
-        lo, hi = max(0, idx - before), min(len(objs), idx + after + 1)
-        return [self._as_turn(o) for o in objs[lo:hi]]
+    def _window(self, session_id: str, uuid: str, before: int, after: int,
+                source: str | None) -> list[Turn] | None:
+        """Stream to an anchor and retain only its bounded navigation window."""
+        for path in self._files_for(uuid, session_id, source=source):
+            path_source = source or self.store.indexed_source(path)
+            previous: deque[Turn] = deque(maxlen=max(0, before))
+            out: list[Turn] = []
+            found = False
+            remaining = max(0, after)
+            try:
+                for event in iter_transcript_events(path, source=path_source):
+                    if not found:
+                        if event.uuid == uuid and (
+                                not session_id or event.session_id == session_id):
+                            out = list(previous)
+                            out.append(self._as_turn(event))
+                            found = True
+                            if remaining == 0:
+                                return out
+                        elif is_navigable(event):
+                            previous.append(self._as_turn(event))
+                        continue
 
-    def step(self, session_id: str, uuid: str, direction: str, count: int = 1) -> list[Turn]:
-        loc = self._locate(session_id, uuid)
-        if loc is None:
-            return []
-        objs, idx = loc
+                    if is_navigable(event):
+                        out.append(self._as_turn(event))
+                        remaining -= 1
+                        if remaining == 0:
+                            return out
+            except OSError:
+                # A transcript may be archived/deleted after indexing. Try any
+                # other candidate and degrade to [] instead of crashing recall.
+                continue
+            if found:
+                return out
+        return None
+
+    def expand_around(self, session_id: str, uuid: str, before: int = 2, after: int = 2,
+                      source: str | None = None) -> list[Turn]:
+        window = self._window(session_id, uuid, before, after, source)
+        return window or []
+
+    def step(self, session_id: str, uuid: str, direction: str, count: int = 1,
+             source: str | None = None) -> list[Turn]:
+        if count < 0:
+            raise ValueError(f"count must be non-negative, got {count!r}")
         if direction == "next":
-            target = idx + count
+            window = self._window(session_id, uuid, 0, count, source)
+            if window and len(window) == count + 1:
+                return [window[-1]]
         elif direction == "prev":
-            target = idx - count
+            window = self._window(session_id, uuid, count, 0, source)
+            if window and len(window) == count + 1:
+                return [window[0]]
         else:
             raise ValueError(f"direction must be 'next' or 'prev', got {direction!r}")
-        if 0 <= target < len(objs):
-            return [self._as_turn(objs[target])]
         return []
 
     def grep(self, pattern: str, session_id: str | None = None,
-             scope_cwd: str | None = None) -> list[Anchor]:
+             scope_cwd: str | None = None,
+             source: str | None = None, limit: int = 100) -> list[Anchor]:
+        self._validate_source(source)
+        if limit < 1:
+            return []
         root = repo_root(scope_cwd) if scope_cwd else None
         # Per-path chunk metadata. A file can carry SEVERAL (sid, cwd) pairs —
         # resumed sessions mix sessionIds in one transcript — so this is only a
         # fast-path skip (skip a file when NO row could match) and a fallback for
         # turns lacking their own fields; the authoritative filter is per turn.
-        meta: dict[str, list[tuple[str, str, str]]] = {}  # path -> [(sid, project, cwd)]
-        for sid, path, project, cwd in self.store.db.execute(
-                "SELECT DISTINCT session_id, file_path, project, cwd FROM chunks").fetchall():
-            meta.setdefault(path, []).append((sid, project, cwd))
+        meta: dict[str, list[tuple[str, str, str, str]]] = {}
+        for sid, path, project, cwd, chunk_source in self.store.db.execute(
+                "SELECT DISTINCT session_id, file_path, project, cwd, source FROM chunks"
+                ).fetchall():
+            meta.setdefault(path, []).append((sid, project, cwd, chunk_source))
         # Scan ALL indexed transcripts, not just chunk-bearing ones: a file whose
         # every turn was filtered at extract (harness boilerplate, tool-only) is
         # exactly the under-the-hood content grep exists for.
-        paths = [r[0] for r in self.store.db.execute(
-            "SELECT path FROM indexed_files").fetchall()]
-        known = set(paths)
-        paths += [p for p in meta if p not in known]  # ad-hoc stores / legacy rows
+        indexed = self.store.db.execute(
+            "SELECT path, source FROM indexed_files").fetchall()
+        paths = [(p, s or "claude") for p, s in indexed if not source or s == source]
+        known = {p for p, _ in paths}
+        paths += [(p, rows[0][3]) for p, rows in meta.items()
+                  if p not in known and (not source or rows[0][3] == source)]
         hits: list[Anchor] = []
-        for path in paths:
+        for path, path_source in paths:
             rows = meta.get(path)
             if rows:
-                if session_id and not any(s == session_id for s, _, _ in rows):
+                # Codex files have one stable thread id. Claude resumed/mixed
+                # files may contain raw-only secondary sessions absent from
+                # chunks, so their authoritative filter stays per-event below.
+                if (path_source == "codex" and session_id
+                        and not any(s == session_id for s, _, _, _ in rows)):
                     continue
-                if root and not any(in_scope(c, root) for _, _, c in rows):
-                    continue
-            for o in self._read_turns(path):
-                t_sid = o.get("sessionId") or (rows[0][0] if rows else "")
-                if session_id and t_sid != session_id:
-                    continue
-                t_cwd = o.get("cwd")
-                if root:
-                    if t_cwd:
-                        if not in_scope(t_cwd, root):
-                            continue  # turn provably outside the repo (mixed-cwd file)
-                    elif not rows:
-                        continue  # chunk-less file, no cwd evidence -> not provably in scope
-                blob = json.dumps(o, ensure_ascii=False)
-                if pattern in blob:
-                    project = project_label(t_cwd) if t_cwd else (rows[0][1] if rows else "")
-                    hits.append(Anchor(session_id=t_sid, uuid=o.get("uuid", ""),
-                                       role=o.get("type", ""), snippet=_snippet(blob),
-                                       score=1.0, project=project, when=0))
+            try:
+                # Strictly streaming: the largest local Codex rollout can be
+                # hundreds of MB, and grep touches every indexed transcript.
+                for event in iter_transcript_events(path, source=path_source):
+                    t_sid = event.session_id or (rows[0][0] if rows else "")
+                    if session_id and t_sid != session_id:
+                        continue
+                    t_cwd = event.cwd or (rows[0][2] if rows else "")
+                    if root:
+                        if t_cwd:
+                            if not in_scope(t_cwd, root):
+                                continue
+                        else:
+                            continue  # no cwd evidence -> not provably in scope
+                    blob = json.dumps(sanitize_raw(event.obj), ensure_ascii=False)
+                    if pattern in blob:
+                        project = (project_label(t_cwd) if t_cwd
+                                   else (rows[0][1] if rows else ""))
+                        self._anchor_files[(event.source, t_sid, event.uuid)] = path
+                        hits.append(Anchor(
+                            session_id=t_sid,
+                            uuid=event.uuid,
+                            role=event.role or event.type,
+                            snippet=_match_snippet(blob, pattern),
+                            score=1.0,
+                            project=project,
+                            when=event.ts,
+                            source=event.source,
+                        ))
+                        if len(hits) >= limit:
+                            return hits
+            except OSError:
+                continue
         return hits
 
     def recent_sessions(self, scope_cwd: str | None = None, limit: int = 10,
-                        now: int | None = None) -> list[dict]:
+                        now: int | None = None,
+                        source: str | None = None) -> list[dict]:
+        self._validate_source(source)
         # Freshest sessions first — answers "what's the current state / how fresh is
         # the index" (the top entry's last_activity IS the effective freshness) and
         # surfaces the sessions of a thread spread across resume-created session_ids,
@@ -252,13 +333,15 @@ class Recall:
         root = repo_root(scope_cwd) if scope_cwd else None
         now = int(time.time()) if now is None else now
         out: list[dict] = []
-        for sid, project, last_ts, turns in self.store.recent_sessions(root, limit):
+        for row_source, sid, project, last_ts, turns in self.store.recent_sessions(
+                root, limit, source=source):
             out.append({
                 "session_id": sid,
+                "source": row_source,
                 "project": project,
                 "turns": turns,
                 "last_activity": last_ts,
                 "last_activity_human": humanize_ts(last_ts, now),
-                "label": _snippet(self.store.first_user_text(sid), 120),
+                "label": _snippet(self.store.first_user_text(sid, row_source), 120),
             })
         return out

--- a/src/session_recall/server.py
+++ b/src/session_recall/server.py
@@ -36,40 +36,52 @@ def _r() -> Recall:
 
 
 @mcp.tool()
-def recall_search(query: str, k: int = 10, scope_cwd: str | None = None) -> list[dict]:
-    """Semantically search past Claude Code sessions. Returns ranked anchors.
+def recall_search(query: str, k: int = 10, scope_cwd: str | None = None,
+                  source: str | None = None) -> list[dict]:
+    """Semantically search past Claude Code and Codex sessions. Returns ranked anchors.
 
     scope_cwd: pass your current working directory to restrict results to the
     current project/repo (worktrees collapse to the repo root). Omit it for a
     global, cross-project search.
+    source: optionally restrict to "claude" or "codex"; omit for the shared index.
     """
-    return [_adict(a) for a in _r().recall_search(query, k=k, scope_cwd=scope_cwd)]
+    return [_adict(a) for a in _r().recall_search(
+        query, k=k, scope_cwd=scope_cwd, source=source)]
 
 
 @mcp.tool()
-def expand_around(session_id: str, uuid: str, before: int = 2, after: int = 2) -> list[dict]:
+def expand_around(session_id: str, uuid: str, before: int = 2, after: int = 2,
+                  source: str | None = None) -> list[dict]:
     """Return the raw turns around an anchor (tool calls, outputs, thinking)."""
-    return [asdict(t) for t in _r().expand_around(session_id, uuid, before, after)]
+    return [asdict(t) for t in _r().expand_around(
+        session_id, uuid, before, after, source=source)]
 
 
 @mcp.tool()
-def step(session_id: str, uuid: str, direction: str, count: int = 1) -> list[dict]:
+def step(session_id: str, uuid: str, direction: str, count: int = 1,
+         source: str | None = None) -> list[dict]:
     """Walk to an adjacent turn ('next' or 'prev')."""
-    return [asdict(t) for t in _r().step(session_id, uuid, direction, count)]
+    return [asdict(t) for t in _r().step(
+        session_id, uuid, direction, count, source=source)]
 
 
 @mcp.tool()
-def grep(pattern: str, session_id: str | None = None, scope_cwd: str | None = None) -> list[dict]:
+def grep(pattern: str, session_id: str | None = None, scope_cwd: str | None = None,
+         source: str | None = None, limit: int = 100) -> list[dict]:
     """On-demand substring scan over raw session transcripts.
 
     scope_cwd: pass your current working directory to restrict the scan to the
     current project/repo; omit for a global scan.
+    source: optionally restrict to "claude" or "codex".
+    limit: maximum number of matches returned (default 100).
     """
-    return [_adict(a) for a in _r().grep(pattern, session_id, scope_cwd=scope_cwd)]
+    return [_adict(a) for a in _r().grep(
+        pattern, session_id, scope_cwd=scope_cwd, source=source, limit=limit)]
 
 
 @mcp.tool()
-def recent_sessions(scope_cwd: str | None = None, limit: int = 10) -> list[dict]:
+def recent_sessions(scope_cwd: str | None = None, limit: int = 10,
+                    source: str | None = None) -> list[dict]:
     """List the most recently active past sessions, freshest first — use to see the
     current state of work and how fresh the index is (the top entry's
     last_activity_human is the effective freshness). Also surfaces the sessions of a
@@ -77,10 +89,11 @@ def recent_sessions(scope_cwd: str | None = None, limit: int = 10) -> list[dict]
 
     scope_cwd: pass your current working directory to restrict to the current
     project/repo (worktrees collapse to the repo root); omit for all projects.
-    Each entry: session_id, project, turns, last_activity (epoch),
+    source: optionally restrict to "claude" or "codex".
+    Each entry: source, session_id, project, turns, last_activity (epoch),
     last_activity_human, label (the session's first user prompt).
     """
-    return _r().recent_sessions(scope_cwd=scope_cwd, limit=limit)
+    return _r().recent_sessions(scope_cwd=scope_cwd, limit=limit, source=source)
 
 
 def main():

--- a/src/session_recall/store.py
+++ b/src/session_recall/store.py
@@ -13,7 +13,7 @@ from .scope import scope_clause
 
 _COLS = ["session_id", "uuid", "role", "text", "project", "cwd",
          "git_branch", "ts", "file_path", "byte_offset", "byte_len",
-         "turn_index", "content_hash"]
+         "turn_index", "content_hash", "source"]
 _INT_COLS = {"ts", "byte_offset", "byte_len", "turn_index"}
 
 
@@ -27,15 +27,36 @@ class Store:
         self._schema()
 
     def _schema(self):
-        col_defs = ", ".join(f"{c} INTEGER" if c in _INT_COLS else f"{c} TEXT" for c in _COLS)
+        col_defs = ", ".join(
+            (f"{c} INTEGER" if c in _INT_COLS else
+             "source TEXT NOT NULL DEFAULT 'claude'" if c == "source" else
+             f"{c} TEXT")
+            for c in _COLS
+        )
         self.db.execute(f"CREATE TABLE IF NOT EXISTS chunks(id INTEGER PRIMARY KEY, {col_defs})")
+        # v0.3 adds transcript provenance without rebuilding the (potentially
+        # very large) vector index. Existing rows are Claude Code history.
+        chunk_cols = {row[1] for row in self.db.execute("PRAGMA table_info(chunks)")}
+        if "source" not in chunk_cols:
+            self.db.execute(
+                "ALTER TABLE chunks ADD COLUMN source TEXT NOT NULL DEFAULT 'claude'")
         self.db.execute(
             f"CREATE VIRTUAL TABLE IF NOT EXISTS vec_chunks USING vec0("
             f"chunk_id INTEGER PRIMARY KEY, embedding FLOAT[{EMBED_DIM}])")
         self.db.execute(
             "CREATE VIRTUAL TABLE IF NOT EXISTS fts_chunks USING fts5(text, chunk_id UNINDEXED)")
         self.db.execute(
-            "CREATE TABLE IF NOT EXISTS indexed_files(path TEXT PRIMARY KEY, sig TEXT)")
+            "CREATE TABLE IF NOT EXISTS indexed_files("
+            "path TEXT PRIMARY KEY, sig TEXT, source TEXT NOT NULL DEFAULT 'claude')")
+        indexed_cols = {row[1] for row in self.db.execute("PRAGMA table_info(indexed_files)")}
+        if "source" not in indexed_cols:
+            self.db.execute(
+                "ALTER TABLE indexed_files ADD COLUMN source TEXT NOT NULL DEFAULT 'claude'")
+        self.db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_chunks_source_session "
+            "ON chunks(source, session_id)")
+        self.db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_chunks_file_path ON chunks(file_path)")
         self.db.commit()
 
     def add(self, chunk: Chunk, embedding: "list[float] | bytes") -> int:
@@ -64,6 +85,20 @@ class Store:
             "SELECT c.content_hash, v.embedding FROM chunks c "
             "JOIN vec_chunks v ON v.chunk_id = c.id WHERE c.file_path = ?", (path,))}
 
+    def embeddings_by_session(self, session_id: str, source: str,
+                              sig_prefix: str) -> dict[str, bytes]:
+        """Reuse vectors when a transcript moves (for example into Codex's
+        archive directory). Only rows whose file signature proves the current
+        extractor/embedding space are eligible."""
+        return {content_hash: embedding for content_hash, embedding in self.db.execute(
+            "SELECT c.content_hash, v.embedding FROM chunks c "
+            "JOIN vec_chunks v ON v.chunk_id = c.id "
+            "JOIN indexed_files f ON f.path = c.file_path "
+            "WHERE c.session_id = ? AND c.source = ? "
+            "AND substr(f.sig, 1, ?) = ?",
+            (session_id, source, len(sig_prefix), sig_prefix),
+        )}
+
     def delete_file(self, path: str):
         """Remove all chunks (+ their vec/fts rows) for a file. Called before
         re-indexing a changed file so a growing transcript does not accumulate
@@ -77,13 +112,19 @@ class Store:
             self.db.execute(f"DELETE FROM fts_chunks WHERE chunk_id IN ({marks})", ids)
             self.db.execute("DELETE FROM chunks WHERE file_path = ?", (path,))
 
-    def prune_deleted(self) -> int:
-        """Drop index rows for transcripts that no longer exist on disk. A deleted
+    def prune_deleted(self, source: str | None = None) -> int:
+        """Drop index rows for transcripts that no longer exist on disk.
+
+        ``source`` limits reconciliation to one producer; this matters for a
+        source-selective refresh. A deleted
         file is never re-visited by index_corpus (it only walks existing files), so
         without this its chunks linger forever — polluting recall_search results and
         (pre-resilience) crashing grep on open(). Returns the number of files pruned.
         WHY: docs/decisions/2026-06-27-grep-resilient-to-deleted-transcripts.md"""
-        gone = [r[0] for r in self.db.execute("SELECT path FROM indexed_files").fetchall()
+        source_sql = " WHERE source = ?" if source else ""
+        params = (source,) if source else ()
+        gone = [r[0] for r in self.db.execute(
+                f"SELECT path FROM indexed_files{source_sql}", params).fetchall()
                 if not Path(r[0]).exists()]
         for path in gone:
             self.delete_file(path)  # chunks + vec + fts
@@ -91,34 +132,48 @@ class Store:
         self.db.commit()
         return len(gone)
 
-    def knn(self, query_vec: list[float], n: int, scope_root: str | None = None) -> list[tuple[int, float]]:
-        clause, params = scope_clause("c.cwd", scope_root)
+    @staticmethod
+    def _filters(scope_root: str | None, source: str | None,
+                 *, alias: str = "c") -> tuple[str, list[str]]:
+        clauses: list[str] = []
+        params: list[str] = []
+        scope, scope_params = scope_clause(f"{alias}.cwd", scope_root)
+        if scope:
+            clauses.append(scope)
+            params.extend(scope_params)
+        if source:
+            clauses.append(f"{alias}.source = ?")
+            params.append(source)
+        return " AND ".join(clauses), params
+
+    def knn(self, query_vec: list[float], n: int, scope_root: str | None = None,
+            source: str | None = None) -> list[tuple[int, float]]:
+        clause, params = self._filters(scope_root, source)
         if not clause:
             rows = self.db.execute(
                 "SELECT chunk_id, distance FROM vec_chunks "
                 "WHERE embedding MATCH ? AND k = ? ORDER BY distance",
                 (sqlite_vec.serialize_float32(query_vec), n)).fetchall()
             return [(r[0], r[1]) for r in rows]
-        # Scoped: vec0 KNN can't pre-filter on a joined column, so over-fetch
-        # candidates then filter to the repo, keeping the top n. The brute-force
-        # scan cost is independent of k, so over-fetching is ~free; clamp so a
-        # repo that is a tiny slice of the corpus still gets enough survivors.
-        total = self.db.execute("SELECT count(*) FROM chunks").fetchone()[0]
-        k_over = min(total, max(300, min(n * 30, 2000)))
+        # sqlite-vec supports an IN-subquery prefilter on the vec0 primary key.
+        # Keep the metadata predicate inside that subquery: filtering only
+        # after a global top-k can starve a small source/repo, while asking for
+        # the whole corpus exceeds sqlite-vec 0.1.9's k<=4096 limit.
         rows = self.db.execute(
-            f"SELECT vec_chunks.chunk_id, vec_chunks.distance FROM vec_chunks "
-            f"JOIN chunks c ON c.id = vec_chunks.chunk_id "
-            f"WHERE vec_chunks.embedding MATCH ? AND k = ? AND {clause} "
-            f"ORDER BY vec_chunks.distance LIMIT ?",
-            (sqlite_vec.serialize_float32(query_vec), k_over, *params, n)).fetchall()
+            f"SELECT chunk_id, distance FROM vec_chunks "
+            f"WHERE embedding MATCH ? AND k = ? "
+            f"AND chunk_id IN (SELECT c.id FROM chunks c WHERE {clause}) "
+            f"ORDER BY distance",
+            (sqlite_vec.serialize_float32(query_vec), n, *params)).fetchall()
         return [(r[0], r[1]) for r in rows]
 
-    def fts(self, query: str, n: int, scope_root: str | None = None) -> list[int]:
+    def fts(self, query: str, n: int, scope_root: str | None = None,
+            source: str | None = None) -> list[int]:
         terms = [t for t in query.split() if t]
         if not terms:
             return []
         match = " OR ".join('"' + t.replace('"', '""') + '"' for t in terms)
-        clause, params = scope_clause("c.cwd", scope_root)
+        clause, params = self._filters(scope_root, source)
         # ORDER BY rank (bm25, best first) — without it FTS5 returns rowid order
         # and LIMIT keeps an arbitrary oldest slice instead of the best matches.
         if not clause:
@@ -143,36 +198,46 @@ class Store:
             data[k] = int(data[k])
         return Chunk(**data)
 
-    def recent_sessions(self, scope_root: str | None, limit: int) -> list[tuple]:
+    def recent_sessions(self, scope_root: str | None, limit: int,
+                        source: str | None = None) -> list[tuple]:
         """Sessions by most-recent activity (max ts), optionally scoped to a repo.
-        Returns (session_id, project, last_ts, turns). Tiebreak on session_id so
-        equal-timestamp ordering is deterministic."""
-        clause, params = scope_clause("cwd", scope_root)
+        Returns (source, session_id, project, last_ts, turns). Tiebreaks make
+        equal-timestamp ordering deterministic."""
+        clause, params = self._filters(scope_root, source, alias="chunks")
         where = f" WHERE {clause}" if clause else ""
         return self.db.execute(
-            f"SELECT session_id, project, max(ts) AS last_ts, count(*) AS turns "
-            f"FROM chunks{where} GROUP BY session_id ORDER BY last_ts DESC, session_id LIMIT ?",
+            f"SELECT source, session_id, project, max(ts) AS last_ts, count(*) AS turns "
+            f"FROM chunks{where} GROUP BY source, session_id "
+            f"ORDER BY last_ts DESC, source, session_id LIMIT ?",
             (*params, limit)).fetchall()
 
-    def first_user_text(self, session_id: str) -> str:
+    def first_user_text(self, session_id: str, source: str | None = None) -> str:
         """The session's earliest user prompt — a human label for the session."""
+        source_sql = " AND source = ?" if source else ""
+        params = (session_id, source) if source else (session_id,)
         row = self.db.execute(
             "SELECT text FROM chunks WHERE session_id = ? AND role = 'user' "
-            "ORDER BY turn_index LIMIT 1", (session_id,)).fetchone()
+            f"{source_sql} ORDER BY turn_index LIMIT 1", params).fetchone()
         return row[0] if row else ""
 
-    def mark_indexed(self, path: str, sig: str):
+    def mark_indexed(self, path: str, sig: str, source: str = "claude"):
         # Not committed here — joins the caller's per-file transaction, so the
         # "indexed" marker can never outlive a rolled-back set of chunks.
         self.db.execute(
-            "INSERT INTO indexed_files(path, sig) VALUES (?, ?) "
-            "ON CONFLICT(path) DO UPDATE SET sig = excluded.sig", (path, sig))
+            "INSERT INTO indexed_files(path, sig, source) VALUES (?, ?, ?) "
+            "ON CONFLICT(path) DO UPDATE SET sig = excluded.sig, source = excluded.source",
+            (path, sig, source))
 
     def is_indexed(self, path: str, sig: str) -> bool:
         return self.stored_sig(path) == sig
 
     def stored_sig(self, path: str) -> "str | None":
         row = self.db.execute("SELECT sig FROM indexed_files WHERE path = ?", (path,)).fetchone()
+        return row[0] if row else None
+
+    def indexed_source(self, path: str) -> "str | None":
+        row = self.db.execute(
+            "SELECT source FROM indexed_files WHERE path = ?", (path,)).fetchone()
         return row[0] if row else None
 
     def commit(self):

--- a/src/session_recall/transcripts.py
+++ b/src/session_recall/transcripts.py
@@ -1,0 +1,556 @@
+"""Streaming adapters for Claude Code and Codex JSONL transcripts.
+
+The envelopes are unrelated, so indexing and retrieval consume normalized
+events from here. Files are always streamed: Codex rollouts can be hundreds of
+megabytes and grep may touch the entire corpus.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+import hashlib
+import json
+from pathlib import Path
+import re
+from typing import Any, Iterator
+
+from .models import Chunk
+from .scope import project_label
+
+
+_CODEX_ID = re.compile(
+    r"([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+    r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\.jsonl$"
+)
+_CODEX_HARNESS_TAGS = (
+    "environment_context", "recommended_plugins", "skill", "turn_aborted",
+    "subagent_notification", "image", "user_action",
+)
+_CODEX_HARNESS_BLOCK = re.compile(
+    "|".join(rf"<{tag}>.*?</{tag}>" for tag in _CODEX_HARNESS_TAGS), re.DOTALL,
+)
+
+
+@dataclass(frozen=True)
+class TranscriptFileMeta:
+    source: str
+    session_id: str
+    cwd: str
+    git_branch: str
+    is_sidechain: bool = False
+
+    def __getitem__(self, key: str):
+        # Small mapping compatibility for callers/tests that predate the typed
+        # metadata object.
+        if key == "is_subagent":
+            return self.is_sidechain
+        return getattr(self, key)
+
+
+@dataclass(frozen=True)
+class TranscriptSpec:
+    path: Path
+    project: str
+    source: str
+
+
+@dataclass(frozen=True)
+class TranscriptEvent:
+    source: str
+    obj: dict
+    session_id: str
+    uuid: str
+    cwd: str
+    git_branch: str
+    ts: int
+    timestamp: str
+    role: str
+    type: str
+    content: str
+    byte_offset: int
+    byte_len: int
+    turn_index: int
+
+
+def parse_ts(value) -> int:
+    if isinstance(value, (int, float)):
+        return int(value)
+    if not isinstance(value, str) or not value:
+        return 0
+    try:
+        return int(datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp())
+    except ValueError:
+        return 0
+
+
+def _codex_id_from_path(path: str | Path) -> str:
+    match = _CODEX_ID.search(str(path))
+    return match.group(1) if match else Path(path).stem
+
+
+def _codex_uuid_from_path(path: str | Path) -> str | None:
+    match = _CODEX_ID.search(str(path))
+    return match.group(1) if match else None
+
+
+def codex_cursor(session_id: str, byte_offset: int) -> str:
+    """Stable opaque cursor: rollouts are append-only and may move to archive."""
+    return f"codex:{session_id}:{byte_offset}"
+
+
+def clean_codex_user_text(content: str) -> str | None:
+    cleaned = _CODEX_HARNESS_BLOCK.sub("", content).strip()
+    return cleaned or None
+
+
+def _source_is_subagent(value: Any) -> bool:
+    """Recognize string and nested ``source.subagent`` metadata shapes."""
+    if isinstance(value, str):
+        return value.casefold() == "subagent"
+    if isinstance(value, dict):
+        if "subagent" in value:
+            return True
+        return any(_source_is_subagent(item) for item in value.values())
+    if isinstance(value, list):
+        return any(_source_is_subagent(item) for item in value)
+    return False
+
+
+def _first_session_meta(path: str | Path) -> dict | None:
+    """Find Codex metadata even if a future writer adds a JSON preamble."""
+    with open(path, "rb") as handle:
+        for raw in handle:
+            try:
+                obj = json.loads(raw)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                continue
+            if not isinstance(obj, dict):
+                continue
+            if obj.get("type") == "session_meta" and isinstance(obj.get("payload"), dict):
+                return obj
+            # An ordinary Claude turn proves this is not a Codex rollout and
+            # avoids scanning a whole Claude transcript looking for metadata.
+            if obj.get("type") in {"user", "assistant"} and "message" in obj:
+                return None
+    return None
+
+
+def detect_source(path: str | Path) -> str:
+    return "codex" if _first_session_meta(path) else "claude"
+
+
+def codex_file_header(path: str | Path) -> TranscriptFileMeta:
+    """Read only the first Codex metadata record; no conversation is buffered."""
+    fallback_id = _codex_id_from_path(path)
+    first = _first_session_meta(path) or {}
+    payload = first.get("payload") if first.get("type") == "session_meta" else {}
+    payload = payload if isinstance(payload, dict) else {}
+    source = payload.get("source")
+    is_sidechain = bool(
+        _source_is_subagent(payload.get("thread_source"))
+        or payload.get("agent_path")
+        or _source_is_subagent(source)
+    )
+    git = payload.get("git") if isinstance(payload.get("git"), dict) else {}
+    # id names THIS rollout. session_id can identify the parent in sidechains.
+    session_id = str(
+        payload.get("id") or _codex_uuid_from_path(path)
+        or payload.get("session_id") or fallback_id
+    )
+    return TranscriptFileMeta(
+        source="codex", session_id=session_id, cwd=str(payload.get("cwd") or ""),
+        git_branch=str(git.get("branch") or ""), is_sidechain=is_sidechain,
+    )
+
+
+def codex_file_meta(path: str | Path) -> TranscriptFileMeta:
+    """Return stable identity plus the latest repeated session metadata.
+
+    Discovery/indexing uses :func:`codex_file_header` to avoid an extra full
+    scan. This fuller public helper is useful for diagnostics and metadata-only
+    callers that want resumed cwd/git values.
+    """
+    header = codex_file_header(path)
+    cwd = header.cwd
+    branch = header.git_branch
+    sidechain = header.is_sidechain
+    for event in iter_transcript_events(path, source="codex"):
+        if event.obj.get("type") != "session_meta":
+            continue
+        payload = event.obj.get("payload") or {}
+        if not isinstance(payload, dict):
+            continue
+        cwd = str(payload.get("cwd") or cwd)
+        git = payload.get("git") if isinstance(payload.get("git"), dict) else {}
+        branch = str(git.get("branch") or branch)
+        source = payload.get("source")
+        sidechain = bool(sidechain or _source_is_subagent(payload.get("thread_source"))
+                         or payload.get("agent_path")
+                         or _source_is_subagent(source))
+    return TranscriptFileMeta("codex", header.session_id, cwd, branch, sidechain)
+
+
+def discover_codex_transcripts(sessions_dir: Path, archived_dir: Path) -> list[TranscriptSpec]:
+    candidates: set[Path] = set()
+    for root in (Path(sessions_dir), Path(archived_dir)):
+        if root.is_dir():
+            candidates.update(path for path in root.rglob("*.jsonl") if path.is_file())
+    specs: list[TranscriptSpec] = []
+    for path in sorted(candidates, key=str):
+        meta = codex_file_meta(path)
+        if not meta.is_sidechain:
+            specs.append(TranscriptSpec(path, project_label(meta.cwd), "codex"))
+    return specs
+
+
+def extractor_version(source: str) -> str:
+    versions = {"claude": "2", "codex": "1"}
+    try:
+        return versions[source]
+    except KeyError as exc:
+        raise ValueError(f"unknown transcript source: {source!r}") from exc
+
+
+def _json_preview(value, limit: int) -> str:
+    if isinstance(value, str):
+        rendered = value
+    else:
+        try:
+            rendered = json.dumps(value, ensure_ascii=False)
+        except (TypeError, ValueError):
+            rendered = str(value)
+    return rendered[:limit]
+
+
+def _text_parts(value) -> list[str]:
+    """Flatten public text fields, never ciphertext or signatures."""
+    if isinstance(value, str):
+        return [value] if value.strip() else []
+    if isinstance(value, list):
+        out: list[str] = []
+        for item in value:
+            out.extend(_text_parts(item))
+        return out
+    if not isinstance(value, dict):
+        return []
+    text = value.get("text")
+    if isinstance(text, str) and text.strip():
+        return [text]
+    out: list[str] = []
+    for key in ("content", "summary"):
+        if key in value:
+            out.extend(_text_parts(value[key]))
+    return out
+
+
+def _render_claude(obj: dict) -> str:
+    msg = obj.get("message") or {}
+    content = msg.get("content")
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        kind = block.get("type")
+        if kind == "text":
+            parts.append(block.get("text", ""))
+        elif kind == "thinking":
+            thinking = (block.get("thinking") or "").strip()
+            if thinking:
+                parts.append(f"[thinking] {thinking}")
+        elif kind == "tool_use":
+            parts.append(
+                f"[tool_use:{block.get('name', '')}] "
+                f"{_json_preview(block.get('input', {}), 300)}"
+            )
+        elif kind == "tool_result":
+            parts.append(f"[tool_result] {_json_preview(block.get('content'), 500)}")
+    return "\n".join(part for part in parts if part)
+
+
+def _render_codex(obj: dict) -> str:
+    envelope = obj.get("type")
+    payload = obj.get("payload") or {}
+    if not isinstance(payload, dict):
+        return ""
+    kind = payload.get("type", "")
+    if envelope == "event_msg":
+        if kind in {"user_message", "agent_message"}:
+            message = payload.get("message")
+            if not isinstance(message, str):
+                return ""
+            return message
+        if kind == "agent_reasoning":
+            text = payload.get("text") or payload.get("message")
+            return f"[thinking] {text}" if isinstance(text, str) and text.strip() else ""
+        if kind == "exec_command_end":
+            output = (payload.get("formatted_output") or payload.get("aggregated_output")
+                      or payload.get("stdout") or payload.get("stderr"))
+            return f"[tool_result:exec] {_json_preview(output, 500)}" if output else ""
+        if kind == "patch_apply_end":
+            value = payload.get("changes") or payload.get("stdout") or payload.get("stderr")
+            return f"[tool_result:patch] {_json_preview(value, 500)}" if value else ""
+        if kind == "mcp_tool_call_end":
+            value = payload.get("result")
+            return f"[tool_result:mcp] {_json_preview(value, 500)}" if value else ""
+        if kind == "error":
+            message = payload.get("message")
+            return f"[error] {message}" if isinstance(message, str) else ""
+        return ""
+    if envelope != "response_item":
+        return ""
+    if kind == "message":
+        role = payload.get("role", "")
+        if role not in {"user", "assistant"}:
+            return ""
+        wanted = "input_text" if role == "user" else "output_text"
+        content = payload.get("content") or []
+        parts = [
+            block.get("text", "") for block in content
+            if isinstance(block, dict) and block.get("type") == wanted
+            and isinstance(block.get("text"), str)
+        ]
+        text = "\n".join(part for part in parts if part.strip())
+        return (clean_codex_user_text(text) or "") if role == "user" else text
+    if kind == "reasoning":
+        parts = _text_parts(payload.get("summary") or payload.get("content"))
+        return f"[thinking] {' '.join(parts)}" if parts else ""
+    if kind in {"function_call", "custom_tool_call", "web_search_call", "tool_search_call"}:
+        name = payload.get("name") or kind
+        args = payload.get("arguments", payload.get("input", payload.get("action", {})))
+        return f"[tool_use:{name}] {_json_preview(args, 300)}"
+    if kind in {"function_call_output", "custom_tool_call_output", "tool_search_output"}:
+        return f"[tool_result] {_json_preview(payload.get('output'), 500)}"
+    if kind == "agent_message":
+        parts = _text_parts(payload.get("content"))
+        return f"[agent_message] {' '.join(parts)}" if parts else ""
+    return ""
+
+
+def _codex_role_and_type(obj: dict) -> tuple[str, str]:
+    envelope = obj.get("type", "")
+    payload = obj.get("payload") or {}
+    payload = payload if isinstance(payload, dict) else {}
+    kind = str(payload.get("type") or envelope)
+    if envelope == "response_item" and kind == "message":
+        return str(payload.get("role") or ""), kind
+    if kind == "user_message":
+        return "user", kind
+    if kind in {"agent_message", "agent_reasoning", "reasoning"}:
+        return "assistant", kind
+    if "call" in kind or kind.endswith("_end") or kind.endswith("_output"):
+        return "tool", kind
+    return "", kind
+
+
+def iter_transcript_events(path: str | Path, source: str | None = None) -> Iterator[TranscriptEvent]:
+    """Yield normalized records with byte-stable cursors, one JSONL line at a time."""
+    path = str(path)
+    source = source or detect_source(path)
+    fallback_sid = _codex_id_from_path(path) if source == "codex" else ""
+    session_id = fallback_sid
+    cwd = ""
+    git_branch = ""
+    saw_meta = False
+    offset = 0
+    with open(path, "rb") as handle:
+        for turn_index, raw in enumerate(handle):
+            byte_offset = offset
+            byte_len = len(raw)
+            offset += byte_len
+            try:
+                obj = json.loads(raw)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                continue
+            if not isinstance(obj, dict):
+                continue
+            if source == "claude":
+                message = obj.get("message") or {}
+                timestamp = str(obj.get("timestamp") or "")
+                sid = str(obj.get("sessionId") or "")
+                yield TranscriptEvent(
+                    source=source, obj=obj, session_id=sid,
+                    uuid=str(obj.get("uuid") or f"claude:{sid}:{byte_offset}"),
+                    cwd=str(obj.get("cwd") or ""), git_branch=str(obj.get("gitBranch") or ""),
+                    ts=parse_ts(timestamp), timestamp=timestamp,
+                    role=str(message.get("role") or obj.get("type") or ""),
+                    type=str(obj.get("type") or ""), content=_render_claude(obj),
+                    byte_offset=byte_offset, byte_len=byte_len, turn_index=turn_index,
+                )
+                continue
+
+            payload = obj.get("payload") or {}
+            payload = payload if isinstance(payload, dict) else {}
+            if obj.get("type") == "session_meta":
+                meta_id = str(
+                    payload.get("id") or _codex_uuid_from_path(path)
+                    or payload.get("session_id") or fallback_sid
+                )
+                if not saw_meta:
+                    saw_meta = True
+                    session_id = meta_id
+                # Identity remains the first meta id; repeated resume metadata
+                # may refresh cwd/git for following records.
+                cwd = str(payload.get("cwd") or cwd)
+                git = payload.get("git") if isinstance(payload.get("git"), dict) else {}
+                git_branch = str(git.get("branch") or git_branch)
+            elif obj.get("type") == "turn_context":
+                cwd = str(payload.get("cwd") or cwd)
+            timestamp = str(obj.get("timestamp") or payload.get("timestamp") or "")
+            role, event_type = _codex_role_and_type(obj)
+            yield TranscriptEvent(
+                source=source, obj=obj, session_id=session_id,
+                uuid=codex_cursor(session_id, byte_offset), cwd=cwd, git_branch=git_branch,
+                ts=parse_ts(timestamp), timestamp=timestamp, role=role, type=event_type,
+                content=_render_codex(obj), byte_offset=byte_offset, byte_len=byte_len,
+                turn_index=turn_index,
+            )
+
+
+def sanitize_raw(value: Any) -> Any:
+    """Recursively remove opaque reasoning ciphertext/signatures from output."""
+    if isinstance(value, dict):
+        return {key: sanitize_raw(item) for key, item in value.items()
+                if key not in {"encrypted_content", "signature"}}
+    if isinstance(value, list):
+        return [sanitize_raw(item) for item in value]
+    return value
+
+
+def _claude_shaped(event: TranscriptEvent, *, surface: bool,
+                   role: str = "", event_type: str | None = None,
+                   content: Any = None) -> dict[str, Any]:
+    payload = event.obj.get("payload") or {}
+    payload = payload if isinstance(payload, dict) else {}
+    turn = {
+        "uuid": event.uuid,
+        "sessionId": event.session_id,
+        "cwd": event.cwd,
+        "timestamp": event.timestamp,
+        "type": event_type or event.type,
+        "message": {"role": role or event.role, "content": content if content is not None else []},
+        "__raw": sanitize_raw(event.obj),
+        "__source": event.source,
+        "__surface": surface,
+        "__byte_offset": event.byte_offset,
+        "__byte_len": event.byte_len,
+        "__turn_index": event.turn_index,
+        "__git_branch": event.git_branch,
+    }
+    if payload.get("phase") is not None:
+        turn["phase"] = payload["phase"]
+    return turn
+
+
+def read_transcript(path: str, source: str) -> list[dict[str, Any]]:
+    """Compatibility materializer; production retrieval uses the streaming iterator."""
+    if source == "claude":
+        return [event.obj for event in iter_transcript_events(path, source="claude")]
+    if source != "codex":
+        raise ValueError(f"unknown transcript source: {source!r}")
+
+    events = list(iter_transcript_events(path, source="codex"))
+    turns: list[dict[str, Any]] = []
+    for event in events:
+        obj = event.obj
+        payload = obj.get("payload") or {}
+        payload = payload if isinstance(payload, dict) else {}
+        kind = payload.get("type")
+        envelope = obj.get("type")
+        if envelope == "event_msg" and kind in {"user_message", "agent_message"}:
+            role = "user" if kind == "user_message" else "assistant"
+            content: Any = event.content if role == "user" else [{"type": "text", "text": event.content}]
+            turns.append(_claude_shaped(
+                event, surface=bool(event.content), role=role, event_type=role, content=content))
+            continue
+        if envelope == "response_item" and kind == "message":
+            role = str(payload.get("role") or "")
+            content = (event.content if role == "user"
+                       else ([{"type": "text", "text": event.content}] if event.content else []))
+            turns.append(_claude_shaped(
+                event, surface=False, role=role, event_type=role or "message", content=content))
+            continue
+        if envelope == "response_item" and kind == "reasoning":
+            parts = _text_parts(payload.get("summary") or payload.get("content"))
+            content = ([{"type": "thinking", "thinking": " ".join(parts)}] if parts else [])
+            turns.append(_claude_shaped(
+                event, surface=False, role="assistant", event_type="assistant", content=content))
+            continue
+        if envelope == "response_item" and kind in {
+                "function_call", "custom_tool_call", "web_search_call", "tool_search_call"}:
+            args = payload.get("arguments", payload.get("input", payload.get("action", {})))
+            if isinstance(args, str):
+                try:
+                    args = json.loads(args)
+                except json.JSONDecodeError:
+                    args = {"arguments": args}
+            block = {"type": "tool_use", "name": payload.get("name") or kind,
+                     "input": sanitize_raw(args)}
+            turns.append(_claude_shaped(
+                event, surface=False, role="assistant", event_type="assistant", content=[block]))
+            continue
+        if envelope == "response_item" and kind in {
+                "function_call_output", "custom_tool_call_output", "tool_search_output"}:
+            block = {"type": "tool_result", "content": sanitize_raw(payload.get("output"))}
+            turns.append(_claude_shaped(
+                event, surface=False, role="tool", event_type="tool", content=[block]))
+            continue
+        turns.append(_claude_shaped(event, surface=False, content=[]))
+    return turns
+
+
+def extract_codex_file(path: str, project: str = "") -> list[Chunk]:
+    """Stream only the canonical visible Codex event surface.
+
+    Do not call :func:`read_transcript` here: that compatibility helper
+    materializes every raw record, while real rollouts can be hundreds of MB.
+    response_item user records are intentionally excluded: in real legacy and
+    service rollouts they can contain machine instructions that look like user
+    text. They remain available to explicit grep/expand.
+    """
+    chunks: list[Chunk] = []
+
+    def make_chunk(event: TranscriptEvent, role: str, text: str) -> Chunk:
+        return Chunk(
+            session_id=event.session_id,
+            uuid=event.uuid,
+            role=role,
+            text=text,
+            project=project_label(event.cwd) or project,
+            cwd=event.cwd,
+            git_branch=event.git_branch,
+            ts=event.ts,
+            file_path=path,
+            byte_offset=event.byte_offset,
+            byte_len=event.byte_len,
+            turn_index=event.turn_index,
+            content_hash=hashlib.sha256(text.encode("utf-8")).hexdigest(),
+            source="codex",
+        )
+
+    for event in iter_transcript_events(path, source="codex"):
+        payload = event.obj.get("payload") or {}
+        if not isinstance(payload, dict):
+            continue
+        kind = payload.get("type")
+        if event.obj.get("type") == "event_msg" and kind in {
+                "user_message", "agent_message"}:
+            if not event.content.strip():
+                continue
+            role = "user" if kind == "user_message" else "assistant"
+            chunks.append(make_chunk(event, role, event.content))
+    return chunks
+
+
+def is_navigable(event: TranscriptEvent) -> bool:
+    # Preserve Claude's historic raw-line stepping. Codex bookkeeping records
+    # are skipped so navigation lands on readable messages/tools/reasoning.
+    if event.source == "claude":
+        return True
+    payload = event.obj.get("payload") or {}
+    if (event.obj.get("type") == "response_item" and isinstance(payload, dict)
+            and payload.get("type") == "message"):
+        return False  # mirrored by the canonical event_msg surface
+    return bool(event.content)

--- a/tests/fixtures/codex_session.jsonl.fixture
+++ b/tests/fixtures/codex_session.jsonl.fixture
@@ -1,0 +1,12 @@
+{"timestamp":"2026-07-01T10:00:00Z","type":"session_meta","payload":{"id":"codex-s1","session_id":"codex-s1","cwd":"/Users/me/repo","source":"vscode","thread_source":"user"}}
+{"timestamp":"2026-07-01T10:00:01Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<environment_context>generated cwd</environment_context>"},{"type":"input_text","text":"<recommended_plugins>generated list</recommended_plugins>"}]}}
+{"timestamp":"2026-07-01T10:00:02Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"How do we cache vectors?"}]}}
+{"timestamp":"2026-07-01T10:00:03Z","type":"event_msg","payload":{"type":"user_message","message":"How do we cache vectors?"}}
+{"timestamp":"2026-07-01T10:00:04Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Use a durable SQLite cache."}],"phase":"commentary"}}
+{"timestamp":"2026-07-01T10:00:05Z","type":"event_msg","payload":{"type":"agent_message","message":"Use a durable SQLite cache.","phase":"commentary"}}
+{"timestamp":"2026-07-01T10:00:06Z","type":"response_item","payload":{"type":"reasoning","summary":[{"type":"summary_text","text":"Preserve vectors for unchanged chunks."}],"encrypted_content":"ciphertext-must-never-escape"}}
+{"timestamp":"2026-07-01T10:00:07Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","arguments":"{\"cmd\":\"pytest\"}","call_id":"call-1"}}
+{"timestamp":"2026-07-01T10:00:08Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call-1","output":"81 passed"}}
+{"timestamp":"2026-07-01T10:00:09Z","type":"session_meta","payload":{"id":"must-not-replace-first-id","cwd":"/Users/me/repo-2","source":"vscode","thread_source":"user"}}
+{"timestamp":"2026-07-01T10:00:10Z","type":"event_msg","payload":{"type":"user_message","message":"What about archived sessions?"}}
+{"timestamp":"2026-07-01T10:00:11Z","type":"event_msg","payload":{"type":"agent_message","message":"Scan the archived rollout directory too.","phase":"final"}}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,8 @@ def test_cli_index_then_search(tmp_path, monkeypatch, capsys):
     proj.mkdir(parents=True)
     shutil.copy("tests/fixtures/session_a.jsonl", proj / "session_a.jsonl")
     monkeypatch.setattr(config, "CLAUDE_PROJECTS", tmp_path / "projects")
+    monkeypatch.setattr(config, "CODEX_SESSIONS", tmp_path / "no-codex-sessions")
+    monkeypatch.setattr(config, "CODEX_ARCHIVED_SESSIONS", tmp_path / "no-codex-archive")
     monkeypatch.setattr(config, "DB_PATH", tmp_path / "cli.db")
     monkeypatch.setattr(cli, "make_embedder", lambda: FakeEmbedder())
     monkeypatch.setattr(cli, "make_reranker", lambda: __import__("session_recall.rerank", fromlist=["FakeReranker"]).FakeReranker())
@@ -26,6 +28,8 @@ def test_cli_recent_grep_prune(tmp_path, monkeypatch, capsys):
     proj.mkdir(parents=True)
     shutil.copy("tests/fixtures/session_a.jsonl", proj / "session_a.jsonl")
     monkeypatch.setattr(config, "CLAUDE_PROJECTS", tmp_path / "projects")
+    monkeypatch.setattr(config, "CODEX_SESSIONS", tmp_path / "no-codex-sessions")
+    monkeypatch.setattr(config, "CODEX_ARCHIVED_SESSIONS", tmp_path / "no-codex-archive")
     monkeypatch.setattr(config, "DB_PATH", tmp_path / "cli.db")
     monkeypatch.setattr(cli, "make_embedder", lambda: FakeEmbedder())
     monkeypatch.setattr(cli, "make_reranker", lambda: None)
@@ -36,7 +40,7 @@ def test_cli_recent_grep_prune(tmp_path, monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "sa" in out and "cache embeddings" in out  # session id + first-prompt label
 
-    cli.main(["grep", "tool output not human"])
+    cli.main(["grep", "tool output not human", "--limit", "1"])
     out = capsys.readouterr().out
     assert "u2" in out  # the tool_result turn's uuid
 

--- a/tests/test_codex_integration.py
+++ b/tests/test_codex_integration.py
@@ -1,0 +1,412 @@
+import json
+import shutil
+from pathlib import Path
+
+from session_recall.embed import FakeEmbedder
+from session_recall.index import index_corpus
+from session_recall.retrieve import Recall
+from session_recall.store import Store
+
+
+FIXTURES = Path(__file__).parent / "fixtures"
+CODEX_FIXTURE = FIXTURES / "codex_session.jsonl.fixture"
+CLAUDE_FIXTURE = FIXTURES / "session_a.jsonl"
+
+
+def _write_codex_session(
+    path: Path,
+    *,
+    session_id: str,
+    cwd: str,
+    user_text: str,
+    assistant_text: str,
+    day: int = 2,
+    meta_extra: dict | None = None,
+    tool_output: str | None = None,
+) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    meta = {
+        "id": session_id,
+        "cwd": cwd,
+        "source": "vscode",
+        "thread_source": "user",
+        "git": {"branch": "feature/codex-recall"},
+    }
+    meta.update(meta_extra or {})
+    prefix = f"2026-07-{day:02d}T10:00:"
+    rows = [
+        {"timestamp": prefix + "00Z", "type": "session_meta", "payload": meta},
+        {"timestamp": prefix + "01Z", "type": "event_msg", "payload": {
+            "type": "user_message", "message": user_text,
+        }},
+        {"timestamp": prefix + "02Z", "type": "event_msg", "payload": {
+            "type": "agent_message", "message": assistant_text, "phase": "final",
+        }},
+    ]
+    if tool_output is not None:
+        rows.extend([
+            {"timestamp": prefix + "03Z", "type": "response_item", "payload": {
+                "type": "function_call", "name": "exec_command",
+                "arguments": json.dumps({"cmd": "synthetic integration command"}),
+                "call_id": "call-integration",
+            }},
+            {"timestamp": prefix + "04Z", "type": "response_item", "payload": {
+                "type": "function_call_output", "call_id": "call-integration",
+                "output": tool_output,
+            }},
+        ])
+    path.write_text("".join(json.dumps(row) + "\n" for row in rows))
+    return path
+
+
+def _claude_corpus(tmp_path: Path) -> Path:
+    project = tmp_path / "claude-projects" / "-Users-me-proj"
+    project.mkdir(parents=True)
+    shutil.copy(CLAUDE_FIXTURE, project / "session_a.jsonl")
+    return tmp_path / "claude-projects"
+
+
+def _recall(store: Store) -> Recall:
+    return Recall(store, FakeEmbedder(), None)
+
+
+def test_index_mixes_claude_active_codex_and_archived_codex(tmp_path):
+    claude = _claude_corpus(tmp_path)
+    active = tmp_path / "codex" / "sessions"
+    archive = tmp_path / "codex" / "archived_sessions"
+    active_file = active / "2026" / "07" / "01" / "rollout-active.jsonl"
+    active_file.parent.mkdir(parents=True)
+    shutil.copy(CODEX_FIXTURE, active_file)
+    archived_file = _write_codex_session(
+        archive / "rollout-archived.jsonl",
+        session_id="codex-archived",
+        cwd="/Users/me/archive-repo",
+        user_text="Archived Codex integration question",
+        assistant_text="Archived Codex integration answer",
+        day=3,
+    )
+
+    store = Store(tmp_path / "mixed.db")
+    embedder = FakeEmbedder()
+    assert index_corpus(store, embedder, claude, (active, archive)) == 8
+    assert store.db.execute(
+        "SELECT source, count(*) FROM chunks GROUP BY source ORDER BY source"
+    ).fetchall() == [("claude", 2), ("codex", 6)]
+    assert store.indexed_source(str(active_file)) == "codex"
+    assert store.indexed_source(str(archived_file)) == "codex"
+    assert index_corpus(store, embedder, claude, (active, archive)) == 0
+    store.close()
+
+
+def test_index_skips_every_codex_subagent_marker(tmp_path):
+    active = tmp_path / "sessions"
+    main = _write_codex_session(
+        active / "2026" / "07" / "01" / "main.jsonl",
+        session_id="main-session",
+        cwd="/workspace/main",
+        user_text="Main session question",
+        assistant_text="Main session answer",
+    )
+    sidechains = [
+        _write_codex_session(
+            active / "2026" / "07" / "01" / "thread-source.jsonl",
+            session_id="child-thread-source",
+            cwd="/workspace/main",
+            user_text="thread_source child text",
+            assistant_text="thread_source child answer",
+            meta_extra={"thread_source": "subagent"},
+        ),
+        _write_codex_session(
+            active / "2026" / "07" / "01" / "source-object.jsonl",
+            session_id="child-source-object",
+            cwd="/workspace/main",
+            user_text="source object child text",
+            assistant_text="source object child answer",
+            meta_extra={"source": {"subagent": {"parent": "main-session"}}},
+        ),
+        _write_codex_session(
+            active / "2026" / "07" / "01" / "agent-path.jsonl",
+            session_id="child-agent-path",
+            cwd="/workspace/main",
+            user_text="agent_path child text",
+            assistant_text="agent_path child answer",
+            meta_extra={"agent_path": "/root/worker"},
+        ),
+    ]
+
+    store = Store(tmp_path / "subagents.db")
+    assert index_corpus(
+        store,
+        FakeEmbedder(),
+        tmp_path / "missing-claude",
+        (active, tmp_path / "missing-archive"),
+    ) == 2
+    assert store.db.execute(
+        "SELECT session_id FROM chunks GROUP BY session_id"
+    ).fetchall() == [("main-session",)]
+    assert store.indexed_source(str(main)) == "codex"
+    assert all(store.indexed_source(str(path)) is None for path in sidechains)
+    store.close()
+
+
+def test_search_and_raw_grep_cursors_expand_and_step(tmp_path):
+    active = tmp_path / "sessions"
+    transcript = active / "2026" / "07" / "01" / "rollout-codex-s1.jsonl"
+    transcript.parent.mkdir(parents=True)
+    shutil.copy(CODEX_FIXTURE, transcript)
+    store = Store(tmp_path / "retrieval.db")
+    index_corpus(store, FakeEmbedder(), None, (active, tmp_path / "missing-archive"))
+    recall = _recall(store)
+
+    search_hit = next(
+        hit for hit in recall.recall_search("durable SQLite cache", k=10)
+        if hit.source == "codex" and "durable SQLite" in hit.snippet
+    )
+    search_window = recall.expand_around(
+        search_hit.session_id, search_hit.uuid, before=0, after=1
+    )
+    assert search_window and "durable SQLite cache" in search_window[0].content
+    search_next = recall.step(search_hit.session_id, search_hit.uuid, "next")
+    assert search_next and "Preserve vectors" in search_next[0].content
+
+    grep_hit = next(hit for hit in recall.grep("81 passed") if hit.source == "codex")
+    assert "81 passed" in grep_hit.snippet
+    grep_window = recall.expand_around(
+        grep_hit.session_id, grep_hit.uuid, before=1, after=0
+    )
+    assert any("81 passed" in turn.content for turn in grep_window)
+    assert any("exec_command" in turn.content for turn in grep_window)
+    previous = recall.step(grep_hit.session_id, grep_hit.uuid, "prev")
+    assert previous and "exec_command" in previous[0].content
+
+    assert recall.grep("ciphertext-must-never-escape", source="codex") == []
+    safe_reasoning = recall.grep("Preserve vectors", source="codex")
+    assert safe_reasoning and all(
+        "ciphertext-must-never-escape" not in hit.snippet for hit in safe_reasoning)
+    store.close()
+
+
+def test_chunkless_codex_grep_anchor_falls_back_to_rollout_filename(tmp_path):
+    active = tmp_path / "sessions"
+    session_id = "019f0000-1111-7222-8333-444455556666"
+    path = active / "2026" / "07" / "04" / (
+        f"rollout-2026-07-04T10-00-00-{session_id}.jsonl"
+    )
+    path.parent.mkdir(parents=True)
+    rows = [
+        {"timestamp": "2026-07-04T10:00:00Z", "type": "session_meta", "payload": {
+            "id": session_id, "cwd": "/workspace/chunkless", "source": "vscode",
+        }},
+        {"timestamp": "2026-07-04T10:00:01Z", "type": "response_item", "payload": {
+            "type": "function_call", "name": "exec_command",
+            "arguments": json.dumps({"cmd": "chunkless synthetic command"}),
+            "call_id": "chunkless-call",
+        }},
+        {"timestamp": "2026-07-04T10:00:02Z", "type": "response_item", "payload": {
+            "type": "function_call_output", "call_id": "chunkless-call",
+            "output": "CHUNKLESS_CODEX_OUTPUT_NEEDLE",
+        }},
+    ]
+    path.write_text("".join(json.dumps(row) + "\n" for row in rows))
+
+    store = Store(tmp_path / "chunkless.db")
+    assert index_corpus(store, FakeEmbedder(), None, (active,)) == 0
+    assert store.db.execute("SELECT count(*) FROM chunks").fetchone()[0] == 0
+    assert store.indexed_source(str(path)) == "codex"
+    recall = _recall(store)
+
+    hit = recall.grep(
+        "CHUNKLESS_CODEX_OUTPUT_NEEDLE",
+        scope_cwd="/workspace/chunkless",
+    )[0]
+    assert hit.session_id == session_id and hit.uuid.startswith(f"codex:{session_id}:")
+    expanded = recall.expand_around(hit.session_id, hit.uuid, before=1, after=0)
+    assert any("CHUNKLESS_CODEX_OUTPUT_NEEDLE" in turn.content for turn in expanded)
+    previous = recall.step(hit.session_id, hit.uuid, "prev")
+    assert previous and "chunkless synthetic command" in previous[0].content
+    store.close()
+
+
+def test_scope_source_and_recent_filters_span_mixed_corpus(tmp_path):
+    claude = _claude_corpus(tmp_path)
+    active = tmp_path / "sessions"
+    _write_codex_session(
+        active / "2026" / "07" / "02" / "repo-a.jsonl",
+        session_id="codex-repo-a",
+        cwd="/workspace/repo-a",
+        user_text="Shared scopable memory alpha",
+        assistant_text="Scoped answer alpha",
+        day=2,
+        tool_output="RAW_SCOPE_MARKER alpha",
+    )
+    _write_codex_session(
+        active / "2026" / "07" / "05" / "repo-b.jsonl",
+        session_id="codex-repo-b",
+        cwd="/workspace/repo-b",
+        user_text="Shared scopable memory beta",
+        assistant_text="Scoped answer beta",
+        day=5,
+        tool_output="RAW_SCOPE_MARKER beta",
+    )
+    store = Store(tmp_path / "scope.db")
+    index_corpus(store, FakeEmbedder(), claude, (active, tmp_path / "missing-archive"))
+    recall = _recall(store)
+
+    scoped = recall.recall_search(
+        "shared scopable memory",
+        k=10,
+        scope_cwd="/workspace/repo-a",
+        source="codex",
+    )
+    assert scoped and {hit.session_id for hit in scoped} == {"codex-repo-a"}
+    assert all(hit.source == "codex" for hit in scoped)
+    assert recall.recall_search("cache embeddings", k=5, source="claude")
+
+    grep_hits = recall.grep(
+        "RAW_SCOPE_MARKER",
+        scope_cwd="/workspace/repo-a",
+        source="codex",
+    )
+    assert grep_hits and {hit.session_id for hit in grep_hits} == {"codex-repo-a"}
+
+    recent = recall.recent_sessions(source="codex", limit=10, now=2_000_000_000)
+    assert [item["session_id"] for item in recent] == ["codex-repo-b", "codex-repo-a"]
+    assert all(item["source"] == "codex" for item in recent)
+    assert recent[0]["label"] == "Shared scopable memory beta"
+    scoped_recent = recall.recent_sessions(
+        scope_cwd="/workspace/repo-a", source="codex", limit=10, now=2_000_000_000
+    )
+    assert [item["session_id"] for item in scoped_recent] == ["codex-repo-a"]
+    store.close()
+
+
+def test_missing_claude_and_codex_roots_are_a_noop(tmp_path):
+    store = Store(tmp_path / "missing.db")
+    assert index_corpus(
+        store,
+        FakeEmbedder(),
+        tmp_path / "missing-claude",
+        (tmp_path / "missing-active", tmp_path / "missing-archive"),
+    ) == 0
+    assert store.db.execute("SELECT count(*) FROM indexed_files").fetchone()[0] == 0
+    store.close()
+
+
+def test_archive_move_reuses_vectors_and_rekeys_the_path(tmp_path):
+    class CountingEmbedder(FakeEmbedder):
+        def __init__(self):
+            super().__init__()
+            self.texts_seen = []
+
+        def embed_documents(self, texts):
+            self.texts_seen.extend(texts)
+            return super().embed_documents(texts)
+
+    active = tmp_path / "sessions"
+    archive = tmp_path / "archived_sessions"
+    old = _write_codex_session(
+        active / "2026" / "07" / "02" / "moving.jsonl",
+        session_id="moving-session",
+        cwd="/workspace/moving",
+        user_text="Archive this memory",
+        assistant_text="Archive move keeps vectors",
+    )
+    store = Store(tmp_path / "moving.db")
+    embedder = CountingEmbedder()
+    index_corpus(store, embedder, None, (active, archive))
+    assert embedder.texts_seen
+
+    archive.mkdir(parents=True)
+    moved = archive / "moving.jsonl"
+    old.rename(moved)
+    embedder.texts_seen.clear()
+    assert index_corpus(store, embedder, None, (active, archive)) == 2
+    assert embedder.texts_seen == [], "archive move should reuse same-session vectors"
+    assert store.indexed_source(str(old)) is None
+    assert store.indexed_source(str(moved)) == "codex"
+    store.close()
+
+
+def test_failed_archive_reindex_keeps_old_memory_until_retry(tmp_path):
+    class PoisonEmbedder(FakeEmbedder):
+        def embed_documents(self, texts):
+            if any("poison" in text for text in texts):
+                raise RuntimeError("synthetic provider failure")
+            return super().embed_documents(texts)
+
+    active = tmp_path / "sessions"
+    archive = tmp_path / "archived_sessions"
+    old = _write_codex_session(
+        active / "2026" / "07" / "02" / "moving.jsonl",
+        session_id="moving-failure",
+        cwd="/workspace/moving",
+        user_text="Original durable memory",
+        assistant_text="Original answer",
+    )
+    store = Store(tmp_path / "moving-failure.db")
+    index_corpus(store, FakeEmbedder(), None, (active, archive))
+
+    archive.mkdir(parents=True)
+    moved = archive / "moving.jsonl"
+    old.rename(moved)
+    with moved.open("a") as handle:
+        handle.write(json.dumps({
+            "timestamp": "2026-07-02T10:00:10Z",
+            "type": "event_msg",
+            "payload": {"type": "user_message", "message": "poison new tail"},
+        }) + "\n")
+    index_corpus(store, PoisonEmbedder(), None, (active, archive))
+
+    assert store.fts("Original", 5, source="codex"), \
+        "failed replacement must not erase the previous good memory"
+    assert store.indexed_source(str(old)) == "codex"
+    assert store.indexed_source(str(moved)) is None
+    store.close()
+
+
+def test_source_selective_index_prunes_only_the_selected_source(tmp_path):
+    active = tmp_path / "sessions"
+    archive = tmp_path / "archived_sessions"
+    archive.mkdir(parents=True)
+    path = _write_codex_session(
+        active / "2026" / "07" / "02" / "codex.jsonl",
+        session_id="codex-delete",
+        cwd="/workspace/codex",
+        user_text="Codex memory to delete",
+        assistant_text="Codex answer",
+    )
+    store = Store(tmp_path / "selective.db")
+    index_corpus(store, FakeEmbedder(), None, (active, archive))
+    path.unlink()
+
+    claude_root = tmp_path / "claude-projects"
+    claude_root.mkdir()
+    index_corpus(store, FakeEmbedder(), claude_root, ())
+    assert store.indexed_source(str(path)) == "codex"
+
+    index_corpus(store, FakeEmbedder(), None, (active, archive))
+    assert store.indexed_source(str(path)) is None
+    store.close()
+
+
+def test_missing_previously_indexed_codex_root_is_not_pruned(tmp_path):
+    active = tmp_path / "sessions"
+    archive = tmp_path / "archived_sessions"
+    archived = _write_codex_session(
+        archive / "archived.jsonl",
+        session_id="temporarily-unavailable",
+        cwd="/workspace/archive",
+        user_text="Keep this archived memory",
+        assistant_text="It remains until storage returns",
+    )
+    active.mkdir()
+    store = Store(tmp_path / "unavailable-root.db")
+    index_corpus(store, FakeEmbedder(), None, (active, archive))
+
+    offline = tmp_path / "archived_sessions.offline"
+    archive.rename(offline)
+    index_corpus(store, FakeEmbedder(), None, (active, archive))
+
+    assert store.indexed_source(str(archived)) == "codex"
+    assert store.fts("archived", 5, source="codex")
+    store.close()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,6 +13,16 @@ def test_model_constants():
     assert config.EMBED_DIM == 1024
     assert config.RERANK_MODEL == "rerank-2.5"
 
+
+def test_codex_roots_follow_codex_home(monkeypatch, tmp_path):
+    import importlib
+    with monkeypatch.context() as scoped:
+        scoped.setenv("CODEX_HOME", str(tmp_path / "custom-codex"))
+        importlib.reload(config)
+        assert config.CODEX_SESSIONS == tmp_path / "custom-codex" / "sessions"
+        assert config.CODEX_ARCHIVED_SESSIONS == tmp_path / "custom-codex" / "archived_sessions"
+    importlib.reload(config)
+
 def test_chunk_dataclass():
     c = Chunk(session_id="s", uuid="u", role="user", text="hi", project="p",
               cwd="/c", git_branch="b", ts=1, file_path="/f.jsonl",

--- a/tests/test_retrieve.py
+++ b/tests/test_retrieve.py
@@ -36,6 +36,12 @@ def test_grep_scans_raw(tmp_path):
     assert hits and hits[0].session_id == "sa"
 
 
+def test_grep_limit_bounds_results(tmp_path):
+    r = _built(tmp_path)
+    assert len(r.grep("type", limit=1)) == 1
+    assert r.grep("type", limit=0) == []
+
+
 def test_expand_around_resolves_grep_uuid_not_in_chunks(tmp_path):
     """grep returns uuids of raw turns that never became chunks (tool_result-only
     turns, filtered boilerplate). expand_around must resolve the transcript via
@@ -303,6 +309,83 @@ def test_grep_filters_per_turn_on_mixed_session_file(tmp_path):
     store.close()
 
 
+def test_grep_finds_and_expands_raw_only_secondary_session(tmp_path):
+    """A mixed Claude transcript may contain a secondary session/cwd only in
+    filtered tool traffic, with no chunk metadata and no matching filename."""
+    import json
+    f = tmp_path / "primary-file.jsonl"
+    rows = [
+        {"type": "user", "uuid": "primary", "sessionId": "s-primary",
+         "cwd": "/alpha", "message": {"role": "user", "content": "surface"}},
+        {"type": "user", "uuid": "raw-secondary", "sessionId": "s-secondary",
+         "cwd": "/beta", "message": {"role": "user", "content": [
+             {"type": "tool_result", "content": "RAW_SECONDARY_NEEDLE"},
+         ]}},
+    ]
+    f.write_text("".join(json.dumps(row) + "\n" for row in rows))
+    projects = tmp_path / "projects" / "-Users-me-primary"
+    projects.mkdir(parents=True)
+    target = projects / f.name
+    target.write_bytes(f.read_bytes())
+    store = Store(tmp_path / "raw-secondary.db")
+    emb = FakeEmbedder()
+    index_corpus(store, emb, tmp_path / "projects")
+
+    recall = Recall(store, emb, None)
+    hits = recall.grep(
+        "RAW_SECONDARY_NEEDLE",
+        session_id="s-secondary",
+        scope_cwd="/beta",
+        source="claude",
+    )
+    assert hits and hits[0].uuid == "raw-secondary"
+    assert recall.expand_around(
+        "s-secondary", "raw-secondary", source="claude")
+
+    # A new MCP process has no in-memory grep hint; the streaming locator must
+    # still resolve the raw-only anchor.
+    restarted = Recall(store, emb, None)
+    expanded = restarted.expand_around(
+        "s-secondary", "raw-secondary", source="claude")
+    assert expanded and any(
+        "RAW_SECONDARY_NEEDLE" in turn.content for turn in expanded
+    )
+    store.close()
+
+
+def test_restart_locator_checks_other_file_when_session_has_surface_elsewhere(tmp_path):
+    """A session-id candidate is only a guess: its raw-only anchor may live in
+    another mixed Claude transcript and must still resolve after MCP restart."""
+    import json
+
+    project = tmp_path / "projects" / "-Users-me-mixed"
+    project.mkdir(parents=True)
+    mixed_rows = [
+        {"type": "user", "uuid": "other-surface", "sessionId": "other",
+         "cwd": "/repo", "message": {"role": "user", "content": "surface"}},
+        {"type": "user", "uuid": "raw-target", "sessionId": "shared",
+         "cwd": "/repo", "message": {"role": "user", "content": [
+             {"type": "tool_result", "content": "CROSS_FILE_RAW_NEEDLE"},
+         ]}},
+    ]
+    (project / "a-mixed.jsonl").write_text(
+        "".join(json.dumps(row) + "\n" for row in mixed_rows))
+    (project / "b-surface.jsonl").write_text(json.dumps({
+        "type": "user", "uuid": "shared-surface", "sessionId": "shared",
+        "cwd": "/repo", "message": {"role": "user", "content": "shared surface"},
+    }) + "\n")
+
+    store = Store(tmp_path / "cross-file.db")
+    emb = FakeEmbedder()
+    index_corpus(store, emb, tmp_path / "projects")
+    restarted = Recall(store, emb, None)
+
+    expanded = restarted.expand_around(
+        "shared", "raw-target", before=0, after=0, source="claude")
+    assert expanded and "CROSS_FILE_RAW_NEEDLE" in expanded[0].content
+    store.close()
+
+
 def test_files_for_escapes_like_wildcards_in_session_id(tmp_path):
     """The <session_id>.jsonl fallback interpolates session_id into a LIKE
     pattern: an unescaped '_' (one-any-char wildcard) would resolve session
@@ -338,6 +421,13 @@ def test_recall_search_fts_only_hits_carry_none_score(tmp_path):
     assert hits, "FTS-only degrade must still return keyword hits"
     assert hits[0].score is None, f"keyword-only hit must carry None, got {hits[0].score!r}"
     store.close()
+
+
+def test_invalid_source_is_rejected(tmp_path):
+    import pytest
+    r = _built(tmp_path)
+    with pytest.raises(ValueError, match="source must be"):
+        r.recall_search("cache", source="other")
 
 
 def test_grep_covers_files_with_no_chunks(tmp_path):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -77,6 +77,7 @@ def test_grep_forwards_scope_cwd(tmp_path, monkeypatch):
     store.add(*_mk("u1", "needle", "/Users/me/repoA", 0, file_path=str(fa), session_id="sa"))
     store.add(*_mk("u2", "needle", "/Users/me/repoB", 1, file_path=str(fb), session_id="sb"))
     monkeypatch.setattr(server, "_recall", Recall(store, FakeEmbedder(), FakeReranker()))
-    out = server.grep("needle", scope_cwd="/Users/me/repoA")
+    out = server.grep("needle", scope_cwd="/Users/me/repoA", limit=1)
     assert out and all(o["session_id"] == "sa" for o in out), "server did not forward scope_cwd to grep"
+    assert len(out) == 1
     store.close()

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,5 +1,6 @@
 from session_recall.store import Store
 from session_recall.models import Chunk
+import sqlite3
 
 def _chunk(uuid, text):
     return Chunk(session_id="s", uuid=uuid, role="user", text=text, project="p",
@@ -30,6 +31,74 @@ def test_indexed_marker(tmp_path):
     s.mark_indexed("/f.jsonl", "sig1")
     assert s.is_indexed("/f.jsonl", "sig1")
     assert not s.is_indexed("/f.jsonl", "sig2")  # changed signature
+    s.close()
+
+
+def test_source_provenance_defaults_and_filters(tmp_path):
+    s = Store(tmp_path / "sources.db")
+    claude = _chunk("c1", "shared memory from claude")
+    codex = _chunk("x1", "shared memory from codex")
+    codex.source = "codex"
+    c_id = s.add(claude, [1.0] + [0.0] * 1023)
+    x_id = s.add(codex, [0.0, 1.0] + [0.0] * 1022)
+
+    assert s.get_chunk(c_id).source == "claude"
+    assert s.get_chunk(x_id).source == "codex"
+    assert [cid for cid, _ in s.knn([1.0] + [0.0] * 1023, 5,
+                                     source="codex")] == [x_id]
+    assert s.fts("memory", 5, source="claude") == [c_id]
+    assert s.fts("memory", 5, source="codex") == [x_id]
+    s.close()
+
+
+def test_indexed_file_records_source(tmp_path):
+    s = Store(tmp_path / "sources.db")
+    s.mark_indexed("/codex.jsonl", "sig", source="codex")
+    assert s.indexed_source("/codex.jsonl") == "codex"
+    s.close()
+
+
+def test_existing_claude_database_migrates_source_columns_in_place(tmp_path):
+    """The shared-source upgrade must preserve a v0.2 Claude-only database."""
+    path = tmp_path / "legacy.db"
+    db = sqlite3.connect(path)
+    db.execute(
+        "CREATE TABLE chunks(id INTEGER PRIMARY KEY, session_id TEXT, uuid TEXT, "
+        "role TEXT, text TEXT, project TEXT, cwd TEXT, git_branch TEXT, ts INTEGER, "
+        "file_path TEXT, byte_offset INTEGER, byte_len INTEGER, turn_index INTEGER, "
+        "content_hash TEXT)"
+    )
+    db.execute(
+        "INSERT INTO chunks(session_id, uuid, role, text, project, cwd, git_branch, ts, "
+        "file_path, byte_offset, byte_len, turn_index, content_hash) "
+        "VALUES ('s', 'u', 'user', 'legacy text', 'p', '/p', '', 1, '/old.jsonl', 0, 1, 0, 'h')"
+    )
+    db.execute("CREATE TABLE indexed_files(path TEXT PRIMARY KEY, sig TEXT)")
+    db.execute("INSERT INTO indexed_files VALUES ('/old.jsonl', 'v2:1:1')")
+    db.commit()
+    db.close()
+
+    store = Store(path)
+    assert store.db.execute("SELECT source FROM chunks").fetchone()[0] == "claude"
+    assert store.indexed_source("/old.jsonl") == "claude"
+    assert store.get_chunk(1).source == "claude"
+    store.close()
+
+
+def test_knn_source_filter_cannot_starve_a_small_source(tmp_path):
+    """A small Codex corpus must remain searchable even when hundreds of
+    closer Claude vectors precede it in the global KNN order."""
+    s = Store(tmp_path / "starvation.db")
+    close = [1.0] + [0.0] * 1023
+    far = [0.0, 1.0] + [0.0] * 1022
+    for i in range(305):
+        s.add(_chunk(f"c{i}", f"claude {i}"), close)
+    codex = _chunk("codex-only", "rare codex memory")
+    codex.source = "codex"
+    codex_id = s.add(codex, far)
+
+    hits = s.knn(close, n=1, source="codex")
+    assert hits and hits[0][0] == codex_id
     s.close()
 
 def test_fts_or_join_non_adjacent_terms(tmp_path):

--- a/tests/test_transcripts.py
+++ b/tests/test_transcripts.py
@@ -1,0 +1,216 @@
+import json
+from pathlib import Path
+import shutil
+
+import pytest
+
+from session_recall.transcripts import (
+    TranscriptSpec,
+    codex_file_header,
+    codex_file_meta,
+    discover_codex_transcripts,
+    extract_codex_file,
+    extractor_version,
+    read_transcript,
+)
+
+
+FIX = Path(__file__).parent / "fixtures" / "codex_session.jsonl.fixture"
+
+
+def _text(turn):
+    content = turn["message"]["content"]
+    if isinstance(content, str):
+        return content
+    return "\n".join(
+        block.get("text", "")
+        for block in content
+        if isinstance(block, dict) and block.get("type") == "text"
+    )
+
+
+def test_discovery_finds_active_and_archived_but_skips_subagents(tmp_path):
+    sessions = tmp_path / "sessions"
+    archived = tmp_path / "archived_sessions"
+    active = sessions / "2026" / "07" / "01" / "active.jsonl"
+    active.parent.mkdir(parents=True)
+    archived.mkdir()
+    archived_file = archived / "archived.jsonl"
+    shutil.copy(FIX, active)
+    shutil.copy(FIX, archived_file)
+
+    (active.parent / "subagent-string.jsonl").write_text(json.dumps({
+        "type": "session_meta",
+        "payload": {"id": "child-1", "cwd": "/child", "source": "subagent"},
+    }) + "\n")
+    (active.parent / "subagent-dict.jsonl").write_text(json.dumps({
+        "type": "session_meta",
+        "payload": {"id": "child-2", "cwd": "/child",
+                    "source": {"subagent": {"parent": "root"}}},
+    }) + "\n")
+    (active.parent / "subagent-thread.jsonl").write_text(json.dumps({
+        "type": "session_meta",
+        "payload": {"id": "child-3", "cwd": "/child",
+                    "thread_source": "subagent"},
+    }) + "\n")
+
+    specs = discover_codex_transcripts(sessions, archived)
+
+    assert specs == [
+        TranscriptSpec(path=archived_file, project="repo-2", source="codex"),
+        TranscriptSpec(path=active, project="repo-2", source="codex"),
+    ]
+
+
+def test_repeated_session_meta_keeps_first_id_and_updates_cwd():
+    meta = codex_file_meta(FIX)
+    assert meta["session_id"] == "codex-s1"
+    assert meta["cwd"] == "/Users/me/repo-2"
+    assert meta["is_subagent"] is False
+
+
+def test_codex_normalization_prefers_visible_events_and_preserves_phase():
+    turns = read_transcript(str(FIX), "codex")
+    surface = [turn for turn in turns if turn["__surface"]]
+
+    assert [(turn["message"]["role"], _text(turn)) for turn in surface] == [
+        ("user", "How do we cache vectors?"),
+        ("assistant", "Use a durable SQLite cache."),
+        ("user", "What about archived sessions?"),
+        ("assistant", "Scan the archived rollout directory too."),
+    ]
+    assert [turn.get("phase") for turn in surface] == [None, "commentary", None, "final"]
+    assert all(turn["sessionId"] == "codex-s1" for turn in turns)
+    assert surface[0]["cwd"] == "/Users/me/repo"
+    assert surface[-1]["cwd"] == "/Users/me/repo-2"
+
+    uuids = [turn["uuid"] for turn in turns]
+    assert len(uuids) == len(set(uuids))
+    assert all(uuid.startswith("codex:codex-s1:") for uuid in uuids)
+
+
+def test_codex_normalization_renders_tools_and_safe_reasoning():
+    turns = read_transcript(str(FIX), "codex")
+    serialized = json.dumps(turns)
+    assert "ciphertext-must-never-escape" not in serialized
+    assert "encrypted_content" not in serialized
+
+    thinking = next(
+        block
+        for turn in turns
+        for block in turn["message"]["content"]
+        if isinstance(turn["message"]["content"], list)
+        and isinstance(block, dict) and block.get("type") == "thinking"
+    )
+    assert thinking["thinking"] == "Preserve vectors for unchanged chunks."
+
+    tool_use = next(
+        block
+        for turn in turns
+        for block in turn["message"]["content"]
+        if isinstance(turn["message"]["content"], list)
+        and isinstance(block, dict) and block.get("type") == "tool_use"
+    )
+    assert tool_use == {
+        "type": "tool_use", "name": "exec_command", "input": {"cmd": "pytest"},
+    }
+    tool_result = next(
+        block
+        for turn in turns
+        for block in turn["message"]["content"]
+        if isinstance(turn["message"]["content"], list)
+        and isinstance(block, dict) and block.get("type") == "tool_result"
+    )
+    assert tool_result["content"] == "81 passed"
+
+
+def test_response_messages_remain_available_but_never_become_surface(tmp_path):
+    path = tmp_path / "fallback.jsonl"
+    rows = [
+        {"timestamp": "2026-07-01T10:00:00Z", "type": "session_meta",
+         "payload": {"id": "fallback-s", "cwd": "/repo", "source": "cli"}},
+        {"timestamp": "2026-07-01T10:00:01Z", "type": "response_item",
+         "payload": {"type": "message", "role": "user", "content": [
+             {"type": "input_text", "text":
+              "<environment_context>noise</environment_context>\nFallback question"},
+         ]}},
+        {"timestamp": "2026-07-01T10:00:01Z", "type": "response_item",
+         "payload": {"type": "message", "role": "user", "content": [
+             {"type": "input_text", "text": "Fallback question"},
+         ]}},
+        {"timestamp": "2026-07-01T10:00:02Z", "type": "response_item",
+         "payload": {"type": "message", "role": "assistant", "content": [
+             {"type": "output_text", "text": "Fallback answer"},
+         ], "phase": "final"}},
+    ]
+    path.write_text("".join(json.dumps(row) + "\n" for row in rows))
+
+    turns = read_transcript(str(path), "codex")
+    assert not any(turn["__surface"] for turn in turns)
+    assert [(_text(turn), turn.get("phase")) for turn in turns[1:]] == [
+        ("Fallback question", None),
+        ("Fallback question", None),
+        ("Fallback answer", "final"),
+    ]
+
+
+def test_canonical_user_message_is_preserved_verbatim(tmp_path):
+    path = tmp_path / "canonical.jsonl"
+    message = "<environment_context>part of my prompt</environment_context>\nExplain it."
+    rows = [
+        {"type": "session_meta", "payload": {"id": "canonical-s", "cwd": "/repo"}},
+        {"timestamp": "2026-07-01T10:00:01Z", "type": "event_msg",
+         "payload": {"type": "user_message", "message": message}},
+    ]
+    path.write_text("".join(json.dumps(row) + "\n" for row in rows))
+
+    chunks = extract_codex_file(str(path))
+    assert [chunk.text for chunk in chunks] == [message]
+
+
+def test_header_finds_metadata_after_preamble_and_prefers_filename_uuid(tmp_path):
+    filename_id = "11111111-2222-3333-4444-555555555555"
+    path = tmp_path / f"rollout-2026-07-01T00-00-00-{filename_id}.jsonl"
+    rows = [
+        {"type": "future_preamble", "payload": {"format": 2}},
+        {"type": "session_meta", "payload": {
+            "session_id": "parent-session", "cwd": "/repo", "source": "cli",
+        }},
+    ]
+    path.write_text("not-json\n" + "".join(json.dumps(row) + "\n" for row in rows))
+
+    meta = codex_file_header(path)
+    assert meta.session_id == filename_id
+    assert meta.cwd == "/repo"
+
+
+def test_extract_codex_file_returns_only_surface_chunks_with_offsets():
+    chunks = extract_codex_file(str(FIX), project="fallback-project")
+    assert [(chunk.role, chunk.text) for chunk in chunks] == [
+        ("user", "How do we cache vectors?"),
+        ("assistant", "Use a durable SQLite cache."),
+        ("user", "What about archived sessions?"),
+        ("assistant", "Scan the archived rollout directory too."),
+    ]
+    assert all(chunk.source == "codex" for chunk in chunks)
+    assert all(chunk.session_id == "codex-s1" for chunk in chunks)
+    assert [chunk.project for chunk in chunks] == ["repo", "repo", "repo-2", "repo-2"]
+    assert all(chunk.ts > 0 and chunk.content_hash for chunk in chunks)
+
+    data = FIX.read_bytes()
+    for chunk in chunks:
+        raw = data[chunk.byte_offset:chunk.byte_offset + chunk.byte_len]
+        assert json.loads(raw)["timestamp"]
+        assert chunk.uuid == f"codex:codex-s1:{chunk.byte_offset}"
+
+
+def test_claude_passthrough_and_version_validation(tmp_path):
+    path = tmp_path / "claude.jsonl"
+    raw = {"type": "user", "uuid": "u1", "sessionId": "s1",
+           "message": {"role": "user", "content": "hello"}}
+    path.write_text(json.dumps(raw) + "\n")
+    assert read_transcript(str(path), "claude") == [raw]
+    assert extractor_version("claude") == "2"
+    assert extractor_version("codex") == "1"
+    with pytest.raises(ValueError, match="unknown transcript source"):
+        read_transcript(str(path), "other")


### PR DESCRIPTION
## What changed

- Add streaming normalization and indexing for active and archived Codex rollouts alongside Claude Code transcripts.
- Add `source=claude|codex` provenance and optional source filters across CLI, MCP search, grep, navigation, and recent-session tools.
- Preserve incremental embedding reuse across live transcript updates and Codex archive moves, with source-safe pruning and in-place database migration.
- Add a Codex plugin manifest, shared recall instructions, hook compatibility, privacy documentation, and synthetic Codex fixtures.

## Why

Session Recall previously indexed only Claude Code history. Work performed in Codex could not be recovered through the same semantic memory, and large Codex rollout files require streaming parsing rather than whole-file materialization.

## Impact

Users can search one local index across both hosts while retaining source provenance. Only canonical user/agent surface messages are embedded; tools, reasoning, and service records remain available through explicit raw navigation and grep. Existing Claude embeddings are migrated without a wholesale re-embed.

## Validation

- `109 passed, 1 deselected`
- Python `compileall`
- Codex plugin manifest validation
- `git diff --check`
