### PR TITLE
feat(recall): report FTS-only degradation instead of hiding it

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@ Local, agentic **semantic recall over your Claude Code and Codex session history
 hosts feed one index, so either agent can recover context created by the other. It gives the
 agent five tools (via MCP) so it can resume past work instead of making you re-explain it:
 
-- `recall_search(query)` — find a past discussion **by meaning** (not substring).
+- `recall_search(query)` — find a past discussion **by meaning** (not substring). Answers
+  `{"anchors": [...], "degraded": null | str}`; `degraded` is set when the embedding provider was
+  unreachable and only literal matching ran, so the agent can say so instead of mistaking a
+  lexical miss for an empty history.
 - `expand_around(session_id, uuid)` — a cursor into the raw turn (tool calls, outputs, thinking).
 - `step(session_id, uuid, direction)` — move to an adjacent turn (cheap cursor step).
 - `grep(pattern)` — on-demand substring scan over **all** indexed transcripts, including

--- a/agents/recall.md
+++ b/agents/recall.md
@@ -28,12 +28,16 @@ reconstruct from git logs or memory files when the recall tools can answer.
    to the repo root. Omit it, or retry without it, for cross-project history or when scoped results
    come back thin. Preserve the requested `source` filter across search, expansion, stepping,
    recent, and grep calls.
-2. Hits are ranked snippets that may span several sessions AND several *different* sub-issues.
+2. `recall_search` returns `{"anchors": [...], "degraded": null | str}`. A non-null `degraded`
+   means the embedder was unreachable and the hits are literal keyword matches only — search by
+   exact identifiers instead of paraphrases, report the degradation in your brief, and never
+   conclude "no history" from a thin degraded result.
+3. Hits are ranked snippets that may span several sessions AND several *different* sub-issues.
    Work out which hits belong to the SAME task vs adjacent ones.
-3. For the best 1-3 hits, `expand_around(session_id, uuid)` to read the surrounding arc
+4. For the best 1-3 hits, `expand_around(session_id, uuid)` to read the surrounding arc
    (decision → why → outcome). `step` to walk further. `grep` for exact identifiers (error
    strings, flags, symbols) that semantic search missed.
-4. A task may span multiple sessions/dates — gather them; order by time if it matters.
+5. A task may span multiple sessions/dates — gather them; order by time if it matters.
 
 ## Return ONLY this (≤ ~250 words)
 - **Task:** what it was, one line.

--- a/docs/decisions/2026-07-26-voyage-403-egress-via-netcup.md
+++ b/docs/decisions/2026-07-26-voyage-403-egress-via-netcup.md
@@ -1,0 +1,99 @@
+# Route Voyage traffic through Netcup, and stop hiding FTS-only degradation
+
+**Date:** 2026-07-26 · **Branch:** `claude/plugin-installation-17054b`
+
+## Context
+
+Recall had been quietly broken for a day and a half. `recent_sessions` reported
+the freshest session as **2026-07-24 14:36**, while sessions kept being written
+locally; the indexer log showed the same line on every run:
+
+```
+session-recall: 22 file(s) failed to index (will retry next run):
+  <path>.jsonl: HTTP code 403 from API (<!doctype html>...403 Forbidden)
+indexed 0 chunks from changed transcripts
+```
+
+Two separate failures stacked on top of each other:
+
+- **Egress.** Voyage sits behind Google Cloud Armor and answers **403 with an HTML
+  body** — not a JSON 401 — to requests from the home VPN exit
+  (`91.232.114.134`, Telemagic B.V., NL, a datacenter ASN). The response is
+  identical with no key, a garbage key, and a valid key, so the status code
+  carries no diagnostic signal at all. `ai.mongodb.com` (the Atlas variant of the
+  same API) is blocked from that IP too.
+- **Silence.** `retrieve.py` caught the embedding failure and fell through to
+  FTS-only with a bare `except: pass`. A lexical result set is shaped exactly like
+  a semantic one, so the degradation was invisible: on 2026-07-25 a recall for
+  "two services conflicting over an auth token" returned an unrelated status
+  summary from 15 days earlier, and the conclusion drawn was "the plugin didn't
+  work" rather than "the embedder is down".
+
+## Decision
+
+1. A permanent SOCKS5 exit through Netcup: `ssh -N -D 127.0.0.1:1080 netcup-socks`
+   under a launchd agent (`RunAtLoad` + `KeepAlive`), with a dedicated ssh alias so
+   it does not fight clawdbot over `LocalForward 18789`.
+2. `VOYAGE_API_KEY` and `ALL_PROXY` live in Doppler (`session-recall/dev`). The
+   existing `~/.local/bin/session-recall{,-mcp}` wrappers already ran under
+   `doppler run` — they were repointed from the unrelated `sidekey` project to
+   `session-recall`. Both Claude Code and Codex invoke those wrappers, so one
+   change covers both hosts.
+3. `PySocks` added to the venv — without it the SDK raises "Missing dependencies
+   for SOCKS support" and the proxy silently does nothing.
+4. `recall_search` now answers `{"anchors": [...], "degraded": null | str}`.
+   Internally `SearchResult` subclasses `list`, so every existing caller keeps
+   indexing and iterating unchanged.
+
+## Why
+
+The blockage is on the network path, not in the account or the key — so the fix
+belongs on the network path too. Everything else (a proxy service, a migration of
+the whole tool to the server) solves the same problem with far more moving parts.
+
+The `degraded` flag matters independently of egress. The tool boundary is where an
+agent decides whether to trust a miss. Without the flag, "embedder down" and "not
+in the history" are indistinguishable, and the agent confidently reports the
+second when the first is true — which is exactly what happened, twice, before this
+was diagnosed.
+
+## What we tested
+
+| Probe | Result |
+|---|---|
+| `POST /v1/embeddings` from the Mac, no key | 403 HTML |
+| same, garbage key | 403 HTML |
+| same, valid key from Doppler | 403 HTML |
+| `api.openai.com` without a key (control) | 401 JSON — so 403-HTML is a WAF, not an API |
+| `POST /v1/embeddings` from Netcup, no key | **401** — the request reaches the API |
+| via SOCKS tunnel, valid key | **200**, 1024-dim embedding |
+| `ai.mongodb.com` from the Mac | 403 HTML — the Atlas endpoint is blocked as well |
+| full re-index after the fix | **1323 chunks, zero failures** (was 0 chunks / 22 failures) |
+| the 2026-07-25 query that missed | now ranks the right session first, score 0.863 |
+
+DNS and the TLS chain were checked for interference (Google Trust Services, no
+MITM by FortiClient) — the blocking is genuinely on Voyage's edge.
+
+## Rejected
+
+- **Take an Atlas key instead (`al-` prefix routes the SDK to `ai.mongodb.com`).**
+  That host answers 403 from the same IP, so it changes nothing.
+- **Reverse-proxy on Netcup (nginx + TLS + token).** Works from any machine and is
+  the better answer once other people need it, but it publishes an endpoint to a
+  paid API and adds a service to maintain — for a single user the tunnel is
+  strictly less machinery.
+- **Move session-recall onto the server entirely.** Considered first, since it
+  also enables a team setup. It drags in transcript sync for both Claude and Codex,
+  SSH-stdio for two clients, and moves the whole history off the laptop. Deferred
+  until a team actually exists; the tunnel does not get in its way.
+- **Copies of the key in `~/.claude/settings.json` and `~/.zshenv`.** Built, then
+  reverted once it turned out the wrappers already inject from Doppler — three
+  copies of a secret on disk to solve a problem that had none.
+- **Adding PySocks to `pyproject.toml`.** The SOCKS hop is one user's network
+  workaround, not a property of the tool.
+
+---
+
+Follow-up, deliberately left out of scope: `grep` is a literal substring scan but
+silently accepts regex-looking patterns and returns zero hits for them — the same
+class of defect as the silent FTS fallback, worth its own fix.

--- a/skills/session-recall/SKILL.md
+++ b/skills/session-recall/SKILL.md
@@ -23,6 +23,10 @@ Treat each result's `source` (`claude` or `codex`) as provenance, not relevance.
    explicitly names a host or provenance is material, and preserve that filter while drilling in.
 5. For deeper grounding, inspect the best anchors with `expand_around`, walk with `step`, and use
    `grep` for exact identifiers that semantic search misses.
+6. `recall_search` answers with `{"anchors": [...], "degraded": null | str}`. When `degraded` is
+   set, the embedding provider was unreachable and only literal word matching ran: say so to the
+   user, retry with the exact identifiers you expect, and treat a thin result as inconclusive
+   rather than as "nothing in the history".
 
 ## Deep-recall execution
 

--- a/src/session_recall/retrieve.py
+++ b/src/session_recall/retrieve.py
@@ -28,6 +28,16 @@ def _match_snippet(text: str, pattern: str, n: int = 240) -> str:
     end = min(len(text), start + n)
     return ("…" if start else "") + text[start:end] + ("…" if end < len(text) else "")
 
+class SearchResult(list):
+    """Anchors plus how they were found. Subclasses list so every existing caller
+    keeps indexing and iterating unchanged; `degraded` carries the health note that
+    the tool boundary turns into a warning for the agent."""
+
+    def __init__(self, anchors=(), degraded: str | None = None):
+        super().__init__(anchors)
+        self.degraded = degraded
+
+
 class Recall:
     def __init__(self, store: Store, embedder: Embedder, reranker: "Reranker | None" = None):
         self.store = store
@@ -61,6 +71,7 @@ class Recall:
         root = repo_root(scope_cwd) if scope_cwd else None
         order: list[int] = []
         dist: dict[int, float | None] = {}
+        degraded: str | None = None
         try:
             qv = self.embedder.embed_query(query)
             for cid, d in self.store.knn(
@@ -68,8 +79,14 @@ class Recall:
                     start_ts=start_ts, end_ts=end_ts):
                 order.append(cid)
                 dist[cid] = d
-        except Exception:
-            pass  # embedding unavailable -> FTS-only
+        except Exception as exc:
+            # WHY: docs/decisions/2026-07-26-voyage-403-egress-via-netcup.md
+            # Embedding unavailable -> FTS-only. Never hard-fail: keyword hits still
+            # beat nothing. But say so — a silent fallback looks identical to a
+            # healthy search that found little, and the caller stops trusting recall
+            # instead of fixing the embedder.
+            degraded = (f"fts-only: embeddings unavailable, semantic ranking is off — "
+                        f"only literal word matches are returned ({type(exc).__name__}: {exc})")
         for cid in self.store.fts(
                 query, candidates, scope_root=root, source=source,
                 start_ts=start_ts, end_ts=end_ts):
@@ -77,7 +94,7 @@ class Recall:
                 order.append(cid)
                 dist[cid] = None  # keyword match, no vector distance
         if not order:
-            return []
+            return SearchResult([], degraded)
         # Collapse exact duplicates (same content across resumed sessions / sidechains) so
         # identical text never wastes two top-k slots. All rows stay in the DB (provenance);
         # we keep the highest-priority occurrence (KNN order, then FTS).
@@ -104,7 +121,9 @@ class Recall:
                 ranked = None
 
         if ranked is not None:
-            return [self._anchor(chunk_by_id[distinct[idx]], score) for idx, score in ranked]
+            return SearchResult(
+                [self._anchor(chunk_by_id[distinct[idx]], score) for idx, score in ranked],
+                degraded)
         # no reranker: KNN-similarity order; score monotonic in similarity, metric-
         # agnostic. Keyword-only hits carry None (no distance), not a fake 0.0 that
         # reads as "irrelevant" at the tool boundary.
@@ -113,7 +132,7 @@ class Recall:
             d = dist.get(cid)
             score = round(1.0 / (1.0 + d), 4) if isinstance(d, (int, float)) else None
             out.append(self._anchor(chunk_by_id[cid], score))
-        return out
+        return SearchResult(out, degraded)
 
     def _files_for(self, uuid: str, session_id: str | None,
                    source: str | None = None) -> list[str]:

--- a/src/session_recall/server.py
+++ b/src/session_recall/server.py
@@ -39,8 +39,16 @@ def _r() -> Recall:
 def recall_search(query: str, k: int = 10, scope_cwd: str | None = None,
                   source: str | None = None, start_date: str | None = None,
                   end_date: str | None = None, timezone: str | None = None,
-                  on_date: str | None = None) -> list[dict]:
-    """Semantically search past Claude Code and Codex sessions. Returns ranked anchors.
+                  on_date: str | None = None) -> dict:
+    """Semantically search past Claude Code and Codex sessions.
+
+    Returns {"anchors": [...ranked anchors...], "degraded": null | str}.
+
+    degraded is non-null when the embedding provider was unreachable and the search
+    fell back to literal keyword matching: semantic ranking is OFF, so a thin result
+    set means "not phrased this way in the transcript", NOT "not in the history".
+    Retry with the exact identifiers you expect (error strings, symbols, file names),
+    tell the user the search is degraded, and treat a miss as inconclusive.
 
     scope_cwd: pass your current working directory to restrict results to the
     current project/repo (worktrees collapse to the repo root). Omit it for a
@@ -53,9 +61,11 @@ def recall_search(query: str, k: int = 10, scope_cwd: str | None = None,
     """
     start_ts, end_ts = date_range_to_epoch(
         start_date, end_date, timezone, on_date=on_date)
-    return [_adict(a) for a in _r().recall_search(
+    hits = _r().recall_search(
         query, k=k, scope_cwd=scope_cwd, source=source,
-        start_ts=start_ts, end_ts=end_ts)]
+        start_ts=start_ts, end_ts=end_ts)
+    return {"anchors": [_adict(a) for a in hits],
+            "degraded": getattr(hits, "degraded", None)}
 
 
 @mcp.tool()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -14,15 +14,15 @@ def test_tool_functions_delegate(tmp_path, monkeypatch):
     store = Store(tmp_path / "s.db")
     index_corpus(store, FakeEmbedder(), tmp_path / "projects")
     monkeypatch.setattr(server, "_recall", Recall(store, FakeEmbedder(), FakeReranker()))
-    out = server.recall_search("cache embeddings", k=1)
+    out = server.recall_search("cache embeddings", k=1)["anchors"]
     assert out and "cache" in out[0]["snippet"]
 
     same_day = server.recall_search(
-        "cache embeddings", k=1, on_date="2026-06-01", timezone="UTC")
+        "cache embeddings", k=1, on_date="2026-06-01", timezone="UTC")["anchors"]
     assert same_day and same_day[0]["session_id"] == "sa"
     assert server.recall_search(
         "cache embeddings", k=1, start_date="2026-06-02",
-        end_date="2026-06-02", timezone="UTC") == []
+        end_date="2026-06-02", timezone="UTC")["anchors"] == []
 
 
 def _mk(uuid, text, cwd, slot, file_path="/f.jsonl", session_id="s"):
@@ -48,7 +48,7 @@ def test_recall_search_forwards_scope_cwd(tmp_path, monkeypatch):
             return qvec
 
     monkeypatch.setattr(server, "_recall", Recall(store, _QEmb(), None))
-    out = server.recall_search("anything", k=10, scope_cwd="/Users/me/repoA")
+    out = server.recall_search("anything", k=10, scope_cwd="/Users/me/repoA")["anchors"]
     assert out and all(o["uuid"] == "u1" for o in out), "server did not forward scope_cwd to recall"
     store.close()
 
@@ -57,8 +57,37 @@ def test_recall_search_enriches_with_human_timestamp(tmp_path, monkeypatch):
     store = Store(tmp_path / "h.db")
     store.add(*_mk("u1", "alpha", "/Users/me/repoA", 0))
     monkeypatch.setattr(server, "_recall", Recall(store, FakeEmbedder(), FakeReranker()))
-    out = server.recall_search("alpha", k=1)
+    out = server.recall_search("alpha", k=1)["anchors"]
     assert out and "when_human" in out[0], "raw epoch not enriched with when_human"
+    store.close()
+
+
+def test_recall_search_reports_fts_only_degrade(tmp_path, monkeypatch):
+    """Embedder unreachable -> search runs on FTS alone. The response MUST say so:
+    without the flag a lexical result set is indistinguishable from a semantic one,
+    and the agent concludes the history is empty when it is merely unsearchable."""
+    store = Store(tmp_path / "deg.db")
+    store.add(*_mk("u1", "alpha needle", "/Users/me/repoA", 0))
+
+    class _DownEmb(FakeEmbedder):
+        def embed_query(self, text):
+            raise RuntimeError("embedding api down")
+
+    monkeypatch.setattr(server, "_recall", Recall(store, _DownEmb(), None))
+    out = server.recall_search("needle", k=1)
+    assert out["anchors"], "FTS-only degrade must still return keyword hits"
+    assert out["degraded"], "degrade to FTS-only is not reported in the response"
+    store.close()
+
+
+def test_recall_search_healthy_is_not_flagged(tmp_path, monkeypatch):
+    """A working embedder must leave the flag clear — otherwise the warning is noise
+    and gets ignored exactly when it matters."""
+    store = Store(tmp_path / "ok.db")
+    store.add(*_mk("u1", "alpha needle", "/Users/me/repoA", 0))
+    monkeypatch.setattr(server, "_recall", Recall(store, FakeEmbedder(), FakeReranker()))
+    out = server.recall_search("needle", k=1)
+    assert out["degraded"] is None, "healthy search must not be flagged as degraded"
     store.close()
 
 


### PR DESCRIPTION
## Что и зачем

`recall_search` отвечал голым списком, поэтому поиск, свалившийся в FTS-only
(эмбеддер недоступен), был неотличим от здорового поиска, который просто мало
нашёл. На этой неделе это дважды стоило реальной диагностики: лексический промах
читался как «в истории ничего нет», и работа уходила в обход.

Теперь ответ — `{"anchors": [...], "degraded": null | str}`. Внутри
`SearchResult` наследует `list`, так что вызовы, которые индексируют и
итерируют, не тронуты.

## Что в диффе

- `retrieve.py` — `SearchResult`, признак деградации вместо `except: pass`
- `server.py` — новый контракт ответа + docstring, объясняющий агенту, что
  делать при деградации (искать точными идентификаторами, не считать промах
  доказательством отсутствия)
- `agents/recall.md`, `skills/session-recall/SKILL.md`, `README.md` — то же
  правило для субагента и скилла
- `docs/decisions/2026-07-26-voyage-403-egress-via-netcup.md` — разбор причины:
  Voyage за Cloud Armor отбивает домашний VPN-IP 403-м с HTML-телом, одинаково
  и без ключа, и с валидным; трафик эмбеддингов теперь выходит через Netcup по
  SOCKS. Сама эта часть — конфигурация хоста, в репозиторий не входит.

## Проверка

- 120 тестов зелёные; два новых написаны до кода и падали как надо
- переиндексация после починки: **1323 чанка, ноль отказов** (было 0 чанков и
  22 отказа подряд)
- запрос, который вчера промазал, теперь ставит нужную сессию первой (score 0.863)

🤖 Generated with [Claude Code](https://claude.com/claude-code)