### PR TITLE
build: package metadata, CI, and trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,46 @@
+name: publish
+
+# Publishes to PyPI via Trusted Publishing (OIDC) — no API token exists anywhere,
+# so there is nothing to leak or rotate. PyPI must have a trusted publisher
+# configured for this repo, workflow `publish.yml`, environment `pypi`.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build distributions
+        run: |
+          python -m pip install --upgrade pip build twine
+          python -m build
+          twine check dist/*
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write # the OIDC token PyPI trades for an upload grant
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,51 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  pytest:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.11", "3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      # Live tests hit the real Voyage API and need a key; the default addopts
+      # already deselect them, so CI runs on synthetic fixtures only.
+      - name: Run tests
+        run: pytest -q
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # Catches packaging breakage (bad metadata, missing files) on every PR
+      # instead of at release time, when it is far more annoying.
+      - name: Build and check distributions
+        run: |
+          python -m pip install --upgrade pip build twine
+          python -m build
+          twine check dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,28 @@
 [project]
 name = "session-recall"
 version = "0.4.0"
+description = "Semantic recall over your local Claude Code and Codex session history — one shared index, searchable by meaning"
+readme = "README.md"
 requires-python = ">=3.11"
+license = "MIT"
+license-files = ["LICENSE"]
+authors = [{ name = "Max Butorin" }]
+keywords = [
+    "claude-code", "codex", "mcp", "semantic-search", "embeddings",
+    "agent-memory", "session-history", "rag",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Operating System :: MacOS",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Text Processing :: Indexing",
+]
 dependencies = [
     "sqlite-vec==0.1.9",
     "voyageai>=0.3.0",
@@ -21,8 +42,13 @@ session-recall-mcp = "session_recall.server:main"
 markers = ["live: hits real Voyage API (needs VOYAGE_API_KEY); excluded by default"]
 addopts = "-m 'not live'"
 
+[project.urls]
+Homepage = "https://github.com/AbsoluteMode/session-recall"
+Repository = "https://github.com/AbsoluteMode/session-recall"
+Issues = "https://github.com/AbsoluteMode/session-recall/issues"
+
 [build-system]
-requires = ["setuptools>=68"]
+requires = ["setuptools>=77"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## Зачем

В `pyproject.toml` были только `name`, `version` и зависимости — ни описания, ни лицензии,
ни readme, ни ссылок, ни классификаторов. В таком виде пакет нельзя опубликовать так, чтобы
он выглядел прилично. Плюс в репозитории вообще не было CI.

## Что внутри

- **Метаданные**: summary, readme, SPDX-лицензия `MIT`, автор, keywords, 10 классификаторов,
  ссылки на репозиторий и issues.
- **`tests.yml`**: pytest на 3.11/3.12/3.13 × Linux/macOS + отдельная job со сборкой
  (`python -m build` + `twine check`) на каждый PR — чтобы упаковка ломалась на PR, а не в
  момент релиза.
- **`publish.yml`**: публикация на PyPI через Trusted Publishing (OIDC) по событию release.
  Токенов не существует нигде — нечему утекать и нечего ротировать.

## Проверено локально

```
Successfully built session_recall-0.4.0.tar.gz and session_recall-0.4.0-py3-none-any.whl
twine check: PASSED (оба артефакта)
```

Метаданные в колесе на месте, оба console scripts (`session-recall`, `session-recall-mcp`)
объявлены.

## Что нужно сделать руками (я туда не хожу)

На pypi.org завести trusted publisher для проекта `session-recall`:
owner `AbsoluteMode`, репозиторий `session-recall`, workflow `publish.yml`, environment `pypi`.
Имя `session-recall` на PyPI сейчас свободно.

🤖 Generated with [Claude Code](https://claude.com/claude-code)