### PR TITLE
feat(cli): show what the index holds, lead README with the payoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,27 @@
 # session-recall
 
-Local, agentic **semantic recall over your Claude Code and Codex session history** — one index
-shared by two different engines. Claude can read what Codex worked out yesterday, Codex can read
-Claude's, and neither needs you to re-explain it. Not a summary file someone maintains by hand:
-the actual turns, including tool calls and reasoning, searchable by meaning.
+**Shared memory for Claude Code and Codex.** Pick up work from a month ago without
+re-explaining it — and Claude can read what Codex worked out yesterday, because both engines
+feed one index. Not a summary file someone maintains by hand: the actual turns, including tool
+calls and reasoning, searchable by meaning.
+
+```console
+$ session-recall index
+indexed 2175 chunks from changed transcripts
+
+your history: 1052 sessions spanning 168 days, 40,035 searchable fragments
+  Claude Code 372 · Codex 680
+  busiest: sidekey, trend_detection, glitch
+```
+
+Then your agent stops asking you what you were doing:
+
+> **you:** we were fixing the auth token conflict between the two services — where did we land?
+>
+> **agent:** *(recall_search → expand_around)* Both services shared one OAuth account, and the
+> provider rotates refresh tokens per account, so each refresh invalidated the other's copy. You
+> rejected the shared-credentials-directory patch as too coupled, and settled on a keeper service
+> owning the session. The spec was never written — that was the next step.
 
 Five tools over MCP:
 

--- a/src/session_recall/cli.py
+++ b/src/session_recall/cli.py
@@ -1,6 +1,6 @@
 import argparse
 from . import config
-from .store import Store
+from .store import Store, corpus_summary
 from .embed import make_embedder
 from .rerank import make_reranker
 from .index import index_corpus
@@ -22,6 +22,28 @@ def _date_range(args, parser: argparse.ArgumentParser) -> tuple[int | None, int 
             args.start_date, args.end_date, args.timezone, on_date=args.date)
     except ValueError as exc:
         parser.error(str(exc))
+
+
+_SOURCE_LABELS = {"claude": "Claude Code", "codex": "Codex"}
+
+
+def _print_corpus_summary(store: Store) -> None:
+    """Say what the user now has. A raw chunk count reads as noise right after
+    install — the interesting facts are how far back the memory reaches and that
+    both engines feed it."""
+    s = corpus_summary(store)
+    if not s["sessions"]:
+        return
+    span = f" spanning {s['span_days']} days" if s["span_days"] else ""
+    print(f"\nyour history: {s['sessions']} sessions{span}, "
+          f"{s['chunks']:,} searchable fragments")
+    if s["by_source"]:
+        print("  " + " · ".join(
+            f"{_SOURCE_LABELS.get(src, src)} {n}"
+            for src, n in sorted(s["by_source"].items())))
+    if s["top_projects"]:
+        print("  busiest: " + ", ".join(p for p, _ in s["top_projects"]))
+    print('\ntry: session-recall search "why did we choose"')
 
 
 def main(argv=None):
@@ -63,6 +85,7 @@ def main(argv=None):
             codex_dirs=codex_roots,
         )
         print(f"indexed {n} chunks from changed transcripts")
+        _print_corpus_summary(store)
     elif args.cmd == "search":
         recall = Recall(store, make_embedder(), make_reranker())
         start_ts, end_ts = _date_range(args, parser)

--- a/src/session_recall/store.py
+++ b/src/session_recall/store.py
@@ -308,3 +308,28 @@ class Store:
     def close(self):
         self.db.commit()  # no-op when nothing is pending; saves ad-hoc writers
         self.db.close()
+
+
+def corpus_summary(store: Store, top_n: int = 3) -> dict:
+    """What the index actually holds, for the line printed after `index`.
+
+    A chunk count means nothing to someone who just installed this. Sessions, the
+    span they cover and the split across engines do — especially the split, since a
+    shared Claude + Codex history is the point of the tool and a chunk total hides it
+    completely.
+    """
+    chunks, sessions, first, last = store.db.execute(
+        "SELECT COUNT(*), COUNT(DISTINCT session_id), MIN(ts), MAX(ts) "
+        "FROM chunks WHERE ts > 0").fetchone()
+    by_source = dict(store.db.execute(
+        "SELECT source, COUNT(DISTINCT session_id) FROM chunks GROUP BY source"))
+    top_projects = store.db.execute(
+        "SELECT project, COUNT(*) c FROM chunks WHERE project IS NOT NULL "
+        "GROUP BY project ORDER BY c DESC LIMIT ?", (top_n,)).fetchall()
+    return {
+        "chunks": chunks or 0,
+        "sessions": sessions or 0,
+        "by_source": by_source,
+        "span_days": round((last - first) / 86400) if first and last else 0,
+        "top_projects": [(p, c) for p, c in top_projects],
+    }

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -339,3 +339,33 @@ def test_dimension_change_fails_loudly_instead_of_looking_like_a_dead_embedder(t
     msg = str(exc.value).lower()
     assert "dimension" in msg, "the error must name the actual problem"
     assert "index" in msg, "and must say what to do about it"
+
+
+def test_corpus_summary_reports_what_was_actually_indexed(tmp_path):
+    """`indexed N chunks` tells a new user nothing about what they now have. The
+    summary has to answer 'what is in there' — how many sessions, over what span,
+    and from which engines, because a shared Claude+Codex history is the whole point
+    and is invisible in a chunk count."""
+    from session_recall.store import Store, corpus_summary
+
+    def chunk(uuid, session_id, project, ts, source="claude"):
+        return Chunk(session_id=session_id, uuid=uuid, role="user", text=uuid,
+                     project=project, cwd="/c", git_branch="b", ts=ts,
+                     file_path="/f.jsonl", byte_offset=0, byte_len=5, turn_index=0,
+                     content_hash=uuid, source=source)
+
+    s = Store(tmp_path / "sum.db")
+    day = 86400
+    vec = [0.0] * 1024
+    s.add(chunk("u1", "s1", "proj-a", 1_700_000_000), vec)
+    s.add(chunk("u2", "s1", "proj-a", 1_700_000_000 + day), vec)
+    s.add(chunk("u3", "s2", "proj-b", 1_700_000_000 + 2 * day, source="codex"), vec)
+    s.db.commit()
+
+    out = corpus_summary(s)
+    assert out["chunks"] == 3
+    assert out["sessions"] == 2
+    assert out["by_source"] == {"claude": 1, "codex": 1}, "sessions per engine, not chunks"
+    assert out["span_days"] == 2
+    assert out["top_projects"][0] == ("proj-a", 2), "busiest project first, with its chunk count"
+    s.close()


### PR DESCRIPTION
## Зачем

`indexed 2175 chunks from changed transcripts` — первое, что видит человек после установки,
и оно не говорит ему ничего. Сколько сессий? За какой период? Что там вообще лежит?
Главное — из счётчика чанков **не видно, что историю кормят оба движка**, хотя ровно это и
отличает инструмент от всех остальных.

## Стало

```
indexed 2175 chunks from changed transcripts

your history: 1052 sessions spanning 168 days, 40,035 searchable fragments
  Claude Code 372 · Codex 680
  busiest: sidekey, trend_detection, glitch

try: session-recall search "why did we choose"
```

Реальный вывод на живой истории, не выдуманный.

## README

Открывается пользой, а не устройством: «Shared memory for Claude Code and Codex. Pick up work
from a month ago without re-explaining it». Дальше — этот же вывод и разыгранный пример
восстановления контекста, вместо описания того, как оно было бы.

Описание и топики репозитория обновлены отдельно: прежнее описание упоминало только Claude Code
и перечисляло механизмы (MCP tools + subagent + skill + hook) вместо того, ради чего это ставят.

## Проверка

136 тестов зелёные, новый писался до кода. Сводка считается одним запросом на таблицу и не
трогает горячий путь поиска.

🤖 Generated with [Claude Code](https://claude.com/claude-code)