### PR TITLE
feat(health): answer whether recall is actually working

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,24 @@ then on, so the index keeps up with both hosts on its own.
 
 ### Troubleshooting
 
+Start here — it checks the whole chain and exits non-zero when something is actually
+broken, so it also works from a timer:
+
+```console
+$ session-recall health
+[ok  ] Freshness  2 minutes behind
+[warn] Embedder   responded in 5828 ms
+                  → slow provider will make indexing crawl
+[ok  ] Corpus     1053 sessions (claude 373, codex 680)
+[ok  ] Sources    claude, codex present
+
+verdict: AMBER (voyage/voyage-4-large, index at ~/.local/share/session-recall/index.db)
+```
+
+Freshness compares the newest transcript on disk against the newest turn in the index,
+so an indexer that runs on every session and fails every time still shows as behind —
+which is exactly the failure that is otherwise invisible.
+
 | Symptom | Cause |
 |---|---|
 | `recall_search` answers with `degraded` set | The embedding provider is unreachable — only literal word matching ran. Results are still real, but a miss proves nothing. |

--- a/src/session_recall/cli.py
+++ b/src/session_recall/cli.py
@@ -1,4 +1,5 @@
 import argparse
+from pathlib import Path
 from . import config
 from .store import Store, corpus_summary
 from .embed import make_embedder
@@ -25,6 +26,28 @@ def _date_range(args, parser: argparse.ArgumentParser) -> tuple[int | None, int 
 
 
 _SOURCE_LABELS = {"claude": "Claude Code", "codex": "Codex"}
+_ZONE_MARKS = {"GREEN": "ok  ", "AMBER": "warn", "RED": "FAIL"}
+
+
+def _run_health(store: Store) -> int:
+    """Print one row per dimension and a verdict. Exit code is non-zero on RED so a
+    timer or monitor can act on it without parsing the text."""
+    from .health import check_all
+
+    roots = {"claude": config.CLAUDE_PROJECTS, "codex": config.CODEX_SESSIONS}
+    transcripts = [p for root in (config.CLAUDE_PROJECTS, config.CODEX_SESSIONS,
+                                  config.CODEX_ARCHIVED_SESSIONS)
+                   if Path(root).is_dir() for p in Path(root).rglob("*.jsonl")]
+    report = check_all(store, make_embedder(), roots, transcripts)
+
+    width = max(len(d.name) for d in report.dimensions)
+    for d in report.dimensions:
+        print(f"[{_ZONE_MARKS[d.zone]}] {d.name.ljust(width)}  {d.detail}")
+        if d.hint:
+            print(f"{' ' * (width + 9)}→ {d.hint}")
+    print(f"\nverdict: {report.verdict}"
+          f" ({config.EMBED_PROVIDER}/{config.EMBED_MODEL}, index at {config.DB_PATH})")
+    return 1 if report.verdict == "RED" else 0
 
 
 def _print_corpus_summary(store: Store) -> None:
@@ -71,9 +94,12 @@ def main(argv=None):
     _add_date_args(gp)
     pp = sub.add_parser("prune")  # drop rows for transcripts deleted from disk
     pp.add_argument("--source", choices=("claude", "codex"))
+    sub.add_parser("health")  # is recall actually working right now?
     args = parser.parse_args(argv)
 
     store = Store(config.DB_PATH)
+    if args.cmd == "health":
+        return _run_health(store)
     if args.cmd == "index":
         claude_root = config.CLAUDE_PROJECTS if args.source in {"all", "claude"} else None
         codex_roots = ((config.CODEX_SESSIONS, config.CODEX_ARCHIVED_SESSIONS)

--- a/src/session_recall/health.py
+++ b/src/session_recall/health.py
@@ -1,0 +1,135 @@
+# src/session_recall/health.py
+"""Answers "is recall actually working right now?".
+
+Written after a failure that stayed invisible for a day and a half: the embedding
+provider started refusing requests, indexing silently stopped, and search kept
+returning plausible keyword hits the whole time. Nothing in the tool said a word.
+
+Each dimension is a small check returning the same shape, so `session-recall health`
+is a table and not a wall of prose. Every failing dimension carries a hint — a symptom
+without a next step just moves the confusion.
+WHY: docs/decisions/2026-07-26-voyage-403-egress-via-netcup.md
+"""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from .store import Store
+
+
+@dataclass(frozen=True)
+class Dimension:
+    name: str
+    zone: str  # GREEN | AMBER | RED
+    detail: str
+    hint: str = ""
+
+
+@dataclass(frozen=True)
+class Score:
+    zone: str
+    value: float
+
+
+def score(value: float, green: float, amber: float,
+          higher_is_better: bool = True) -> Score:
+    """Bucket a measurement. Directional because some dimensions improve as the number
+    grows (sessions indexed) and others as it shrinks (hours since the last index)."""
+    if higher_is_better:
+        zone = "GREEN" if value >= green else "AMBER" if value >= amber else "RED"
+    else:
+        zone = "GREEN" if value <= green else "AMBER" if value <= amber else "RED"
+    return Score(zone=zone, value=value)
+
+
+def _humanize_lag(seconds: float) -> str:
+    if seconds < 3600:
+        return f"{int(seconds // 60)} minutes behind"
+    if seconds < 86400:
+        return f"{seconds / 3600:.1f} hours behind"
+    return f"{seconds / 86400:.1f} days behind"
+
+
+def check_freshness(store: Store, transcripts: list[Path]) -> Dimension:
+    """Gap between the newest transcript on disk and the newest turn in the index.
+
+    Deliberately not "when did the index last change": an indexer that runs every
+    session and fails every time keeps its own timestamp fresh while falling further
+    and further behind reality. Only the comparison against disk catches that.
+    """
+    newest_indexed = store.db.execute("SELECT MAX(ts) FROM chunks").fetchone()[0] or 0
+    on_disk = [p.stat().st_mtime for p in transcripts if p.exists()]
+    if not on_disk:
+        return Dimension("Freshness", "AMBER", "no transcripts found on disk",
+                         "check the source paths below")
+    lag = max(on_disk) - newest_indexed
+    zone = score(lag / 3600, green=6, amber=48, higher_is_better=False).zone
+    return Dimension(
+        "Freshness", zone, _humanize_lag(lag) if lag > 0 else "up to date",
+        "" if zone == "GREEN" else
+        "run `session-recall index` and read its output — indexing is failing, not idle")
+
+
+def check_corpus(store: Store) -> Dimension:
+    """Sessions per engine. A single total hides the failure worth catching: one
+    source quietly stopping while the other keeps the number growing."""
+    per_source = dict(store.db.execute(
+        "SELECT source, COUNT(DISTINCT session_id) FROM chunks GROUP BY source"))
+    total = sum(per_source.values())
+    zone = score(total, green=20, amber=1).zone
+    detail = ", ".join(f"{src} {n}" for src, n in sorted(per_source.items())) or "empty"
+    return Dimension("Corpus", zone, f"{total} sessions ({detail})",
+                     "" if zone == "GREEN" else "run `session-recall index` to populate")
+
+
+def check_paths(roots: dict[str, Path]) -> Dimension:
+    """A mistyped CODEX_HOME indexes nothing and is indistinguishable from having no
+    Codex history at all — so name the sources that are not there."""
+    missing = [name for name, path in roots.items() if not Path(path).exists()]
+    if not missing:
+        return Dimension("Sources", "GREEN", ", ".join(sorted(roots)) + " present")
+    zone = "RED" if len(missing) == len(roots) else "AMBER"
+    return Dimension("Sources", zone, f"missing: {', '.join(sorted(missing))}",
+                     "set CODEX_HOME / SESSION_RECALL_CLAUDE_PROJECTS if these live elsewhere")
+
+
+def check_embedder(embedder) -> Dimension:
+    """One real embedding call. Quote whatever comes back verbatim: a generic
+    "unavailable" is what sent us chasing the API key yesterday, when the key was
+    fine and an IP-level block was answering 403 to everyone."""
+    started = time.monotonic()
+    try:
+        embedder.embed_query("health check")
+    except Exception as exc:
+        return Dimension(
+            "Embedder", "RED", f"{type(exc).__name__}: {exc}"[:160],
+            "search still runs on keyword matching only; a 403 with an HTML body is "
+            "usually the network path, not the key")
+    elapsed_ms = (time.monotonic() - started) * 1000
+    zone = score(elapsed_ms, green=2000, amber=8000, higher_is_better=False).zone
+    return Dimension("Embedder", zone, f"responded in {elapsed_ms:.0f} ms",
+                     "" if zone == "GREEN" else "slow provider will make indexing crawl")
+
+
+@dataclass(frozen=True)
+class Report:
+    dimensions: list[Dimension]
+    verdict: str
+
+
+def check_all(store: Store, embedder, roots: dict[str, Path],
+              transcripts: list[Path]) -> Report:
+    """Every dimension plus one verdict. The verdict is the worst zone present: a
+    single dead dimension makes recall untrustworthy, and averaging would hide it
+    behind everything that still works."""
+    dims = [
+        check_freshness(store, transcripts),
+        check_embedder(embedder),
+        check_corpus(store),
+        check_paths(roots),
+    ]
+    order = {"GREEN": 0, "AMBER": 1, "RED": 2}
+    verdict = max((d.zone for d in dims), key=lambda z: order[z])
+    return Report(dimensions=dims, verdict=verdict)

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,116 @@
+# tests/test_health.py
+import time
+
+from session_recall.health import score, check_freshness, check_corpus, check_paths
+from session_recall.models import Chunk
+from session_recall.store import Store
+
+
+def _chunk(uuid, ts, session_id="s1", source="claude"):
+    return Chunk(session_id=session_id, uuid=uuid, role="user", text=uuid, project="p",
+                 cwd="/c", git_branch="b", ts=ts, file_path="/f.jsonl", byte_offset=0,
+                 byte_len=5, turn_index=0, content_hash=uuid, source=source)
+
+
+def test_score_bands_and_direction():
+    """One scoring rule for every dimension, and it has to work in both directions:
+    more sessions is better, more hours since the last index is worse."""
+    assert score(100, green=50, amber=10).zone == "GREEN"
+    assert score(20, green=50, amber=10).zone == "AMBER"
+    assert score(2, green=50, amber=10).zone == "RED"
+    assert score(1, green=24, amber=72, higher_is_better=False).zone == "GREEN"
+    assert score(100, green=24, amber=72, higher_is_better=False).zone == "RED"
+
+
+def test_freshness_measures_the_gap_to_disk_not_the_index_alone(tmp_path):
+    """The failure that went unnoticed for a day and a half: the index kept answering
+    happily while transcripts on disk moved on without it. An index-only timestamp
+    cannot see that — the gap between newest-on-disk and newest-indexed can."""
+    store = Store(tmp_path / "h.db")
+    old = int(time.time()) - 3 * 86400
+    store.add(_chunk("u1", old), [0.0] * 1024)
+    store.db.commit()
+
+    transcript = tmp_path / "live.jsonl"
+    transcript.write_text("{}\n")  # written now, three days after the newest chunk
+
+    dim = check_freshness(store, [transcript])
+    assert dim.zone == "RED", "a three-day gap must not read as healthy"
+    assert "day" in dim.detail or "hour" in dim.detail, "detail must state the actual lag"
+    assert dim.hint, "every failing dimension must say what to do about it"
+    store.close()
+
+
+def test_freshness_is_green_when_the_index_has_caught_up(tmp_path):
+    store = Store(tmp_path / "h2.db")
+    store.add(_chunk("u1", int(time.time())), [0.0] * 1024)
+    store.db.commit()
+    transcript = tmp_path / "live.jsonl"
+    transcript.write_text("{}\n")
+    assert check_freshness(store, [transcript]).zone == "GREEN"
+    store.close()
+
+
+def test_corpus_counts_sessions_per_engine(tmp_path):
+    """A total hides the failure worth catching: one source silently stopping."""
+    store = Store(tmp_path / "c.db")
+    now = int(time.time())
+    store.add(_chunk("u1", now, session_id="s1"), [0.0] * 1024)
+    store.add(_chunk("u2", now, session_id="s2", source="codex"), [0.0] * 1024)
+    store.db.commit()
+
+    dim = check_corpus(store)
+    assert "claude" in dim.detail and "codex" in dim.detail
+    store.close()
+
+
+def test_paths_reports_which_sources_are_missing(tmp_path):
+    """A wrong CODEX_HOME indexes nothing and looks exactly like having no Codex history."""
+    present = tmp_path / "claude"
+    present.mkdir()
+    dim = check_paths({"claude": present, "codex": tmp_path / "nope"})
+    assert dim.zone != "GREEN"
+    assert "codex" in dim.detail, "the missing source must be named"
+
+
+def test_embedder_check_surfaces_the_real_error(tmp_path):
+    """Yesterday's failure verbatim: the provider answered 403 and the tool reported
+    nothing. The check must quote what actually came back — 'unavailable' would have
+    sent us to look at the key, which was fine."""
+    from session_recall.health import check_embedder
+
+    class _Down:
+        def embed_query(self, text):
+            raise RuntimeError("HTTP code 403 from API")
+
+    dim = check_embedder(_Down())
+    assert dim.zone == "RED"
+    assert "403" in dim.detail, "the provider's own words, not a generic label"
+    assert dim.hint
+
+
+def test_embedder_check_is_green_when_it_answers():
+    from session_recall.embed import FakeEmbedder
+    from session_recall.health import check_embedder
+    assert check_embedder(FakeEmbedder()).zone == "GREEN"
+
+
+def test_check_all_reports_every_dimension_and_a_verdict(tmp_path):
+    """`health` has to answer one question first — is it working — and only then
+    explain. A list of rows without a verdict makes the user do the aggregation."""
+    from session_recall.embed import FakeEmbedder
+    from session_recall.health import check_all
+
+    store = Store(tmp_path / "all.db")
+    store.add(_chunk("u1", int(time.time())), [0.0] * 1024)
+    store.db.commit()
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text("{}\n")
+
+    report = check_all(store, FakeEmbedder(), {"claude": tmp_path}, [transcript])
+    names = {d.name for d in report.dimensions}
+    assert {"Freshness", "Corpus", "Sources", "Embedder"} <= names
+    assert report.verdict in {"GREEN", "AMBER", "RED"}
+    assert report.verdict == "RED" if any(
+        d.zone == "RED" for d in report.dimensions) else True, "worst zone wins"
+    store.close()


### PR DESCRIPTION
## Зачем

Вчера провайдер эмбеддингов начал отбивать запросы, индексация встала, а поиск полтора суток
продолжал возвращать правдоподобные лексические хиты. Инструмент не сказал ни слова — и вывод
был сделан ровно тот, которого мы боимся: «плагин не работает».

## `session-recall health`

```
[ok  ] Freshness  2 minutes behind
[warn] Embedder   responded in 5828 ms
                  → slow provider will make indexing crawl
[ok  ] Corpus     1053 sessions (claude 373, codex 680)
[ok  ] Sources    claude, codex present

verdict: AMBER (voyage/voyage-4-large, index at ~/.local/share/session-recall/index.db)
```

Живой вывод на реальной истории. Код возврата ненулевой при RED — можно вешать на таймер.

## Почему измерения именно такие

- **Freshness** сравнивает свежайший транскрипт на диске со свежайшим турном в индексе, а не
  «когда индекс менялся». Индексатор, который запускается каждую сессию и каждый раз падает,
  исправно обновляет собственную метку, отставая всё сильнее — поймать это можно только
  сравнением с диском.
- **Embedder** делает один настоящий вызов и цитирует ошибку дословно. Обобщённое
  «unavailable» — ровно то, из-за чего мы вчера полезли проверять ключ, который был исправен.
- **Corpus** считает сессии **по движкам**: суммарное число прячет ситуацию, когда один
  источник тихо перестал индексироваться.
- **Sources** называет отсутствующие каталоги: опечатка в `CODEX_HOME` не индексирует ничего
  и выглядит точно как «у меня просто нет истории Codex».

Вердикт — худшая зона, а не среднее: одно мёртвое измерение делает recall ненадёжным вне
зависимости от того, что ещё работает.

## Проверка

144 теста зелёные (было 136), восемь новых писались до кода.

🤖 Generated with [Claude Code](https://claude.com/claude-code)