### PR TITLE
build: pin mcp<2 — unbreak CI after mcp 2.0.0 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 dependencies = [
     "sqlite-vec==0.1.9",
     "voyageai>=0.3.0",
-    "mcp>=1.2.0",
+    "mcp>=1.2.0,<2",
     "pysqlite3>=0.6.0; sys_platform == 'darwin'",
 ]
 


### PR DESCRIPTION
mcp 2.0.0 вышел на PyPI и удалил `mcp.server.fastmcp` — незапиненный `mcp>=1.2.0` уронил все матрицы CI (`ModuleNotFoundError` на сборе тестов, PR #12). Пин `<2` возвращает зелёный CI; миграция на 2.x API — отдельная задача.

🤖 Generated with [Claude Code](https://claude.com/claude-code)