### PR TITLE
feat(share): pairing, trust store, signed E2E envelopes (gate v1, PR 1/4)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "sqlite-vec==0.1.9",
     "voyageai>=0.3.0",
     "mcp>=1.2.0,<2",
+    "pynacl>=1.5",
     "pysqlite3>=0.6.0; sys_platform == 'darwin'",
 ]
 

--- a/src/session_recall/cli.py
+++ b/src/session_recall/cli.py
@@ -95,7 +95,12 @@ def main(argv=None):
     pp = sub.add_parser("prune")  # drop rows for transcripts deleted from disk
     pp.add_argument("--source", choices=("claude", "codex"))
     sub.add_parser("health")  # is recall actually working right now?
+    from .share import cli as share_cli
+    share_cli.add_parser(sub)
     args = parser.parse_args(argv)
+
+    if args.cmd == "share":  # no Store: share state lives outside the index DB
+        return share_cli.run(args)
 
     store = Store(config.DB_PATH)
     if args.cmd == "health":

--- a/src/session_recall/share/__init__.py
+++ b/src/session_recall/share/__init__.py
@@ -1,0 +1,14 @@
+"""P2P recall sharing — pairing, trust and envelopes.
+
+Spec: docs/decisions/2026-07-30-p2p-sharing-v1-security-gate.md
+"""
+
+from pathlib import Path
+
+from .. import config
+
+
+def share_dir() -> Path:
+    """Resolved lazily so tests (and a relocated XDG home) can repoint
+    config.DATA_DIR without re-importing the package."""
+    return config.DATA_DIR / "share"

--- a/src/session_recall/share/cli.py
+++ b/src/session_recall/share/cli.py
@@ -1,0 +1,142 @@
+"""`session-recall share …` — the human-only surface of the share protocol.
+
+Every trust mutation lives here and only here: no MCP tool reaches identity,
+pairing or the trust store (gate §2). The ceremony is deliberately split into
+invite/join/complete → read the SAS aloud → trust, so the human check cannot
+be skipped by automation.
+"""
+
+import argparse
+import os
+
+from .. import config
+from . import identity as identity_mod
+from . import pairing
+from .pairing import PairingError
+from .transport import from_env
+from .trust import Peer, TrustStore
+
+_TRANSPORT_HINT = (
+    "no transport configured: set SESSION_RECALL_RELAY_URL (relay) or "
+    "SESSION_RECALL_SHARE_TRANSPORT_DIR (shared folder)")
+
+
+def add_parser(sub) -> None:
+    shp = sub.add_parser("share", help="p2p recall sharing: pairing and trust")
+    ssub = shp.add_subparsers(dest="share_cmd", required=True)
+    ip = ssub.add_parser("init", help="create this device's share identity")
+    ip.add_argument("name", help="how you introduce yourself to peers")
+    ssub.add_parser("invite", help="start pairing; prints a one-time code")
+    jp = ssub.add_parser("join", help="accept an invite code from a peer")
+    jp.add_argument("code")
+    ssub.add_parser("complete", help="finish pairing after the peer joined")
+    ssub.add_parser("trust", help="confirm the SAS matched; enroll the peer")
+    ssub.add_parser("devices", help="list trusted peers")
+    rp = ssub.add_parser("revoke", help="revoke a peer by name or address")
+    rp.add_argument("peer")
+    ap = ssub.add_parser("allow", help="mark a project shareable (no arg: list)")
+    ap.add_argument("project", nargs="?")
+    ap.add_argument("--remove", action="store_true")
+
+
+def _sas_block(res: pairing.PairingResult) -> str:
+    return (f"paired with: {res.bundle['name']} ({res.bundle['address']})\n"
+            f"\n    SAS code: {res.sas}\n\n"
+            "Read it aloud to each other over a channel you trust. If BOTH see "
+            "the same code, each side runs: session-recall share trust")
+
+
+def run(args: argparse.Namespace) -> int:
+    sdir = config.DATA_DIR / "share"
+    cmd = args.share_cmd
+
+    if cmd == "init":
+        try:
+            ident = identity_mod.create(sdir, args.name)
+        except FileExistsError as exc:
+            print(exc)
+            return 1
+        print(f"share identity created for {ident.name}\n"
+              f"your address: {ident.address}\n"
+              "next: session-recall share invite   (or join a peer's invite)")
+        return 0
+
+    ident = identity_mod.load(sdir)
+    if ident is None:
+        print("no share identity — run: session-recall share init <your-name>")
+        return 1
+    trust = TrustStore(sdir / "trust.json")
+
+    if cmd in ("invite", "join", "complete"):
+        transport = from_env(os.environ)
+        if transport is None:
+            print(_TRANSPORT_HINT)
+            return 1
+        try:
+            if cmd == "invite":
+                code = pairing.start_invite(ident, transport, sdir)
+                print(f"one-time invite code (valid {pairing.INVITE_TTL_S // 60} min):\n\n"
+                      f"    {code}\n\n"
+                      "hand it to your peer out-of-band. After they run "
+                      "`share join <code>`, run: session-recall share complete")
+            elif cmd == "join":
+                print(_sas_block(pairing.join(ident, transport, sdir, args.code)))
+            else:
+                print(_sas_block(pairing.complete_invite(ident, transport, sdir)))
+        except PairingError as exc:
+            print(f"pairing failed: {exc}")
+            return 1
+        return 0
+
+    if cmd == "trust":
+        cand = pairing.pending_peer(sdir)
+        if cand is None:
+            print("nothing to trust — finish a pairing (join/complete) first")
+            return 1
+        b = cand["bundle"]
+        try:
+            trust.add(Peer(name=b["name"], address=b["address"],
+                           sign_pk=b["sign_pk"], box_pk=b["box_pk"]))
+        except ValueError as exc:
+            print(exc)
+            return 1
+        pairing.clear_pending_peer(sdir)
+        print(f"trusted: {b['name']} ({b['address']}), mode=accept\n"
+              "they can ask you questions once the answering service ships; "
+              "revoke anytime: session-recall share revoke " + b["name"])
+        return 0
+
+    if cmd == "devices":
+        peers = trust.peers(include_revoked=True)
+        if not peers:
+            print("no trusted peers yet")
+            return 0
+        for p in peers:
+            mark = "REVOKED " if p.revoked else ""
+            print(f"{mark}{p.name}  {p.address}  mode={p.mode}")
+        return 0
+
+    if cmd == "revoke":
+        peer = trust.revoke(args.peer)
+        if peer is None:
+            print(f"no active peer matching {args.peer!r}")
+            return 1
+        print(f"revoked: {peer.name} ({peer.address}) — their envelopes now drop silently")
+        return 0
+
+    if cmd == "allow":
+        if args.project is None:
+            allowed = trust.allowed_projects()
+            print("\n".join(allowed) if allowed else
+                  "no shareable projects (default deny) — add one: "
+                  "session-recall share allow <project>")
+            return 0
+        if args.remove:
+            trust.disallow_project(args.project)
+            print(f"no longer shareable: {args.project}")
+        else:
+            trust.allow_project(args.project)
+            print(f"shareable: {args.project}")
+        return 0
+
+    return 1

--- a/src/session_recall/share/crypto.py
+++ b/src/session_recall/share/crypto.py
@@ -1,0 +1,64 @@
+"""Thin helpers over libsodium (PyNaCl) for the share protocol.
+
+Gate rule (docs/decisions/2026-07-30-p2p-sharing-v1-security-gate.md): no
+hand-rolled primitives. Everything here is Ed25519 / X25519 / XSalsa20-Poly1305
+/ BLAKE2b straight from libsodium; this module only fixes encodings and the SAS
+derivation so both sides compute them identically.
+"""
+
+import base64
+import json
+import secrets
+
+from nacl import hash as nacl_hash
+from nacl.encoding import RawEncoder
+
+
+def b64(data: bytes) -> str:
+    return base64.b64encode(data).decode("ascii")
+
+
+def unb64(data: str) -> bytes:
+    return base64.b64decode(data.encode("ascii"))
+
+
+def b32(data: bytes) -> str:
+    """Lowercase base32 without padding — addresses and invite codes. Survives
+    voice, chat clients and URL paths, unlike base64's mixed case and '/'. """
+    return base64.b32encode(data).decode("ascii").rstrip("=").lower()
+
+
+def unb32(text: str) -> bytes:
+    clean = text.replace("-", "").replace(" ", "").upper()
+    return base64.b32decode(clean + "=" * (-len(clean) % 8))
+
+
+def new_address() -> str:
+    """128 random bits. Defeats enumeration/bruteforce of inboxes; it is NOT a
+    secret and NOT authentication — signatures are (gate §3)."""
+    return b32(secrets.token_bytes(16))
+
+
+def canonical(obj: dict) -> bytes:
+    """Stable bytes for signing: sorted keys, no whitespace. Both ends must
+    produce the identical byte string or signatures cannot verify."""
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"),
+                      ensure_ascii=False).encode("utf-8")
+
+
+def sas_code(*parts: bytes) -> str:
+    """Short authentication string both humans read aloud after pairing.
+
+    Order-independent (parts are sorted) so inviter and joiner compute the same
+    code without agreeing who is 'first'. 8 digits in two groups — enough to
+    make a relay-substitution attack visible, short enough to actually be read.
+    """
+    digest = nacl_hash.blake2b(b"\x00".join(sorted(parts)),
+                               digest_size=8, encoder=RawEncoder)
+    num = int.from_bytes(digest, "big") % 10**8
+    return f"{num:08d}"[:4] + " " + f"{num:08d}"[4:]
+
+
+def group(text: str, size: int = 4) -> str:
+    """xxxx-xxxx-… presentation for codes the user copies around."""
+    return "-".join(text[i:i + size] for i in range(0, len(text), size))

--- a/src/session_recall/share/envelope.py
+++ b/src/session_recall/share/envelope.py
@@ -1,0 +1,156 @@
+"""Signed, end-to-end encrypted request/response envelopes + the fail-closed
+inbound gate: signature, freshness, replay, rate.
+
+open_request/open_response return None for anything unacceptable — unknown or
+revoked sender, bad signature, stale timestamp, replayed nonce, rate excess.
+Silent drop is deliberate (gate §3): an error reply would confirm the address
+exists and leak which check failed.
+"""
+
+import json
+import os
+import stat
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from nacl.exceptions import CryptoError
+from nacl.public import Box, PrivateKey, PublicKey
+from nacl.signing import VerifyKey
+
+from .crypto import b64, unb64, canonical
+from .identity import Identity
+from .trust import Peer, TrustStore
+
+REQ_TTL_S = 600            # clock skew between two laptops + relay latency
+RATE_PER_MIN = 3           # gate §4
+RATE_PER_DAY = 30          # 3/min alone would still allow 4320/day — the pump
+STATE_FILE = "state.json"
+
+
+class ShareState:
+    """Replay nonces and per-peer rate counters. JSON, not the index DB: this
+    must survive index rebuilds and stay out of any LLM-reachable tool."""
+
+    def __init__(self, path: Path):
+        self.path = path
+        if path.exists():
+            raw = json.loads(path.read_text())
+            self.seen: dict[str, float] = raw.get("seen", {})
+            self.rate: dict[str, list[float]] = raw.get("rate", {})
+        else:
+            self.seen, self.rate = {}, {}
+
+    def _save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self.path.with_suffix(".tmp")
+        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+                     stat.S_IRUSR | stat.S_IWUSR)
+        with os.fdopen(fd, "w") as f:
+            json.dump({"seen": self.seen, "rate": self.rate}, f)
+        os.replace(tmp, self.path)
+
+    def replay(self, nonce: str, now: float) -> bool:
+        self.seen = {n: t for n, t in self.seen.items() if now - t < 2 * REQ_TTL_S}
+        if nonce in self.seen:
+            return True
+        self.seen[nonce] = now
+        self._save()
+        return False
+
+    def rate_exceeded(self, address: str, now: float) -> bool:
+        window = [t for t in self.rate.get(address, []) if now - t < 86400]
+        minute = [t for t in window if now - t < 60]
+        if len(minute) >= RATE_PER_MIN or len(window) >= RATE_PER_DAY:
+            self.rate[address] = window
+            self._save()
+            return True
+        window.append(now)
+        self.rate[address] = window
+        self._save()
+        return False
+
+
+@dataclass
+class Incoming:
+    peer: Peer
+    kind: str          # "req" | "resp"
+    body: dict         # req: {question, task}; resp: {text}
+    nonce: str
+    in_reply_to: str | None
+    ts: float
+
+
+def _sealed(identity: Identity, peer_box_pk: str, kind: str, body: dict,
+            to_address: str, in_reply_to: str | None) -> bytes:
+    box = Box(identity.box_key, PublicKey(unb64(peer_box_pk)))
+    envelope = {
+        "v": 1, "kind": kind,
+        "from": identity.address, "to": to_address,
+        "ts": time.time(), "nonce": b64(os.urandom(16)),
+        "ct": b64(box.encrypt(canonical(body))),
+    }
+    if in_reply_to:
+        envelope["in_reply_to"] = in_reply_to
+    sig = identity.signing_key.sign(canonical(envelope)).signature
+    envelope["sig"] = b64(sig)
+    return json.dumps(envelope).encode()
+
+
+def make_request(identity: Identity, peer: Peer | dict, question: str,
+                 task: str = "") -> bytes:
+    box_pk = peer.box_pk if isinstance(peer, Peer) else peer["box_pk"]
+    address = peer.address if isinstance(peer, Peer) else peer["address"]
+    return _sealed(identity, box_pk, "req",
+                   {"question": question, "task": task}, address, None)
+
+
+def make_response(identity: Identity, peer: Peer, text: str,
+                  in_reply_to: str) -> bytes:
+    return _sealed(identity, peer.box_pk, "resp", {"text": text},
+                   peer.address, in_reply_to)
+
+
+def open_incoming(identity: Identity, trust: TrustStore, state: ShareState,
+                  raw: bytes, now: float | None = None) -> Incoming | None:
+    """The single inbound gate. Order matters: cheap and unauthenticated checks
+    first, the rate counter only after the signature proves the sender —
+    otherwise a stranger could spend a peer's quota by spoofing `from`."""
+    now = time.time() if now is None else now
+    try:
+        env = json.loads(raw)
+    except (ValueError, UnicodeDecodeError):
+        return None
+    if not isinstance(env, dict) or env.get("v") != 1:
+        return None
+    if env.get("kind") not in ("req", "resp"):
+        return None
+    if env.get("to") != identity.address:
+        return None
+
+    peer = trust.get_by_address(env.get("from", ""))
+    if peer is None:                      # unknown or revoked → same silence
+        return None
+    sig = env.pop("sig", None)
+    if not sig:
+        return None
+    try:
+        VerifyKey(unb64(peer.sign_pk)).verify(canonical(env), unb64(sig))
+    except (CryptoError, ValueError):
+        return None
+
+    ts = env.get("ts", 0)
+    if abs(now - ts) > REQ_TTL_S:
+        return None
+    if state.replay(env["nonce"], now):
+        return None
+    if env["kind"] == "req" and state.rate_exceeded(peer.address, now):
+        return None
+
+    try:
+        box = Box(identity.box_key, PublicKey(unb64(peer.box_pk)))
+        body = json.loads(box.decrypt(unb64(env["ct"])))
+    except (CryptoError, ValueError):
+        return None
+    return Incoming(peer=peer, kind=env["kind"], body=body, nonce=env["nonce"],
+                    in_reply_to=env.get("in_reply_to"), ts=ts)

--- a/src/session_recall/share/identity.py
+++ b/src/session_recall/share/identity.py
@@ -1,0 +1,81 @@
+"""Local share identity: one signing keypair, one box keypair, one address.
+
+Lives OUTSIDE the index DB on purpose: rebuilding the index must never rotate
+keys, and the MCP server exposes no tool that touches this file — identity and
+trust management is human-only CLI (gate §2).
+"""
+
+import json
+import os
+import stat
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from nacl.public import PrivateKey
+from nacl.signing import SigningKey
+
+from .crypto import b64, unb64, new_address
+
+IDENTITY_FILE = "identity.json"
+
+
+def _write_private(path: Path, payload: dict) -> None:
+    """0600 from the first byte — never a window where the file is world-readable."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.parent.chmod(0o700)
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, stat.S_IRUSR | stat.S_IWUSR)
+    with os.fdopen(fd, "w") as f:
+        json.dump(payload, f, indent=2)
+
+
+@dataclass
+class Identity:
+    name: str
+    address: str
+    signing_key: SigningKey
+    box_key: PrivateKey
+    created_at: float
+
+    @property
+    def sign_pk_b64(self) -> str:
+        return b64(bytes(self.signing_key.verify_key))
+
+    @property
+    def box_pk_b64(self) -> str:
+        return b64(bytes(self.box_key.public_key))
+
+    def public_bundle(self) -> dict:
+        """What the other side learns about us during pairing. Public keys and a
+        self-chosen name only — nothing here is sensitive."""
+        return {"name": self.name, "address": self.address,
+                "sign_pk": self.sign_pk_b64, "box_pk": self.box_pk_b64}
+
+
+def create(share_dir: Path, name: str) -> Identity:
+    path = share_dir / IDENTITY_FILE
+    if path.exists():
+        raise FileExistsError(
+            f"share identity already exists at {path}; delete it only if you "
+            "mean to abandon every pairing made with it")
+    ident = Identity(name=name, address=new_address(),
+                     signing_key=SigningKey.generate(),
+                     box_key=PrivateKey.generate(), created_at=time.time())
+    _write_private(path, {
+        "v": 1, "name": ident.name, "address": ident.address,
+        "sign_sk": b64(bytes(ident.signing_key)),
+        "box_sk": b64(bytes(ident.box_key)),
+        "created_at": ident.created_at,
+    })
+    return ident
+
+
+def load(share_dir: Path) -> Identity | None:
+    path = share_dir / IDENTITY_FILE
+    if not path.exists():
+        return None
+    data = json.loads(path.read_text())
+    return Identity(name=data["name"], address=data["address"],
+                    signing_key=SigningKey(unb64(data["sign_sk"])),
+                    box_key=PrivateKey(unb64(data["box_sk"])),
+                    created_at=data.get("created_at", 0.0))

--- a/src/session_recall/share/pairing.py
+++ b/src/session_recall/share/pairing.py
@@ -1,0 +1,115 @@
+"""Pairing ceremony: invite code out-of-band, key bundles through the relay,
+SAS verified by voice, then an explicit human `trust` step.
+
+Why this shape (gate §1): the invite code is a one-time 256-bit secretbox key
+that never touches the relay, so the relay cannot read or substitute bundles —
+a MITM without the code fails MAC verification. The SAS read-out on top makes
+a stolen/guessed slot visible to the humans. TOFU ends there; afterwards every
+request is signed by the exchanged keys.
+
+Flow:  A: invite  →  code to B out-of-band  →  B: join <code>  →  A: complete
+       both read the same SAS aloud          →  both: trust
+"""
+
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from nacl.exceptions import CryptoError
+from nacl.secret import SecretBox
+from nacl.utils import random as nacl_random
+
+from .crypto import b32, unb32, b64, unb64, canonical, sas_code, group
+from .identity import Identity
+
+INVITE_TTL_S = 600
+_ID_LEN, _KEY_LEN = 5, SecretBox.KEY_SIZE
+
+PENDING_INVITE_FILE = "pending_invite.json"
+PENDING_PEER_FILE = "pending_peer.json"
+
+
+class PairingError(Exception):
+    pass
+
+
+@dataclass
+class PairingResult:
+    bundle: dict   # the other side's public bundle
+    sas: str
+
+
+def _seal(key: bytes, bundle: dict) -> bytes:
+    return SecretBox(key).encrypt(canonical({"bundle": bundle, "ts": time.time()}),
+                                  nacl_random(SecretBox.NONCE_SIZE))
+
+
+def _open(key: bytes, blob: bytes, ttl_s: float = INVITE_TTL_S) -> dict:
+    try:
+        payload = json.loads(SecretBox(key).decrypt(blob))
+    except CryptoError as exc:
+        raise PairingError("invite code does not match this exchange "
+                           "(wrong code, or someone tampered with the slot)") from exc
+    if time.time() - payload["ts"] > ttl_s:
+        raise PairingError("invite expired — start a fresh one")
+    return payload["bundle"]
+
+
+def start_invite(identity: Identity, transport, share_dir: Path) -> str:
+    """Returns the code to hand over out-of-band (chat, voice, paper)."""
+    invite_id = nacl_random(_ID_LEN)
+    key = nacl_random(_KEY_LEN)
+    transport.put_slot(f"pair-a-{b32(invite_id)}", _seal(key, identity.public_bundle()))
+    (share_dir / PENDING_INVITE_FILE).write_text(json.dumps(
+        {"invite_id": b32(invite_id), "key": b64(key), "created_at": time.time()}))
+    return group(b32(invite_id + key))
+
+
+def join(identity: Identity, transport, share_dir: Path, code: str) -> PairingResult:
+    raw = unb32(code)
+    if len(raw) != _ID_LEN + _KEY_LEN:
+        raise PairingError("that does not look like an invite code")
+    invite_id, key = b32(raw[:_ID_LEN]), raw[_ID_LEN:]
+    blob = transport.get_slot(f"pair-a-{invite_id}")
+    if blob is None:
+        raise PairingError("invite not found — expired, already used, or wrong code")
+    their = _open(key, blob)
+    transport.put_slot(f"pair-b-{invite_id}", _seal(key, identity.public_bundle()))
+    return _finish(identity, share_dir, their)
+
+
+def complete_invite(identity: Identity, transport, share_dir: Path) -> PairingResult:
+    pending_path = share_dir / PENDING_INVITE_FILE
+    if not pending_path.exists():
+        raise PairingError("no pending invite — run `share invite` first")
+    pending = json.loads(pending_path.read_text())
+    if time.time() - pending["created_at"] > INVITE_TTL_S:
+        pending_path.unlink()
+        raise PairingError("invite expired — start a fresh one")
+    blob = transport.get_slot(f"pair-b-{pending['invite_id']}")
+    if blob is None:
+        raise PairingError("the other side has not joined yet")
+    their = _open(unb64(pending["key"]), blob)
+    pending_path.unlink()
+    return _finish(identity, share_dir, their)
+
+
+def _finish(identity: Identity, share_dir: Path, their: dict) -> PairingResult:
+    sas = sas_code(unb64(identity.sign_pk_b64), unb64(their["sign_pk"]))
+    # Parked until the human confirms the SAS and runs `share trust` — pairing
+    # never writes the trust store itself.
+    (share_dir / PENDING_PEER_FILE).write_text(json.dumps(
+        {"bundle": their, "sas": sas, "ts": time.time()}))
+    return PairingResult(bundle=their, sas=sas)
+
+
+def pending_peer(share_dir: Path) -> dict | None:
+    path = share_dir / PENDING_PEER_FILE
+    return json.loads(path.read_text()) if path.exists() else None
+
+
+def clear_pending_peer(share_dir: Path) -> None:
+    path = share_dir / PENDING_PEER_FILE
+    if path.exists():
+        path.unlink()

--- a/src/session_recall/share/transport.py
+++ b/src/session_recall/share/transport.py
@@ -1,0 +1,121 @@
+"""Transports carry opaque encrypted blobs; they are 100% untrusted.
+
+Everything that crosses a transport is sealed and signed by the layers above
+(pairing: secretbox under the invite key; mail: box + Ed25519). A malicious
+relay can drop or replay bytes — both are handled above — but can neither read
+nor forge. That is why three interchangeable implementations are fine:
+in-memory for tests, a shared directory for two accounts on one machine or a
+synced folder, and the HTTP relay (server lands in the next PR).
+"""
+
+import json
+import secrets
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Protocol
+
+_HTTP_TIMEOUT_S = 10
+
+
+class Transport(Protocol):
+    def put_slot(self, slot: str, blob: bytes) -> None: ...
+    def get_slot(self, slot: str) -> bytes | None: ...
+    def post_mail(self, address: str, blob: bytes) -> None: ...
+    def fetch_mail(self, address: str) -> list[bytes]: ...
+
+
+class InMemoryTransport:
+    def __init__(self):
+        self.slots: dict[str, bytes] = {}
+        self.mail: dict[str, list[bytes]] = {}
+
+    def put_slot(self, slot: str, blob: bytes) -> None:
+        self.slots[slot] = blob
+
+    def get_slot(self, slot: str) -> bytes | None:
+        return self.slots.get(slot)
+
+    def post_mail(self, address: str, blob: bytes) -> None:
+        self.mail.setdefault(address, []).append(blob)
+
+    def fetch_mail(self, address: str) -> list[bytes]:
+        return self.mail.pop(address, [])
+
+
+class FileTransport:
+    """A directory both parties can reach (same machine, synced folder)."""
+
+    def __init__(self, root: Path):
+        self.root = Path(root)
+
+    def put_slot(self, slot: str, blob: bytes) -> None:
+        d = self.root / "slots"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / slot).write_bytes(blob)
+
+    def get_slot(self, slot: str) -> bytes | None:
+        p = self.root / "slots" / slot
+        return p.read_bytes() if p.exists() else None
+
+    def post_mail(self, address: str, blob: bytes) -> None:
+        d = self.root / "mail" / address
+        d.mkdir(parents=True, exist_ok=True)
+        (d / secrets.token_hex(8)).write_bytes(blob)
+
+    def fetch_mail(self, address: str) -> list[bytes]:
+        d = self.root / "mail" / address
+        if not d.is_dir():
+            return []
+        out = []
+        for p in sorted(d.iterdir()):
+            out.append(p.read_bytes())
+            p.unlink()
+        return out
+
+
+class HttpRelayTransport:
+    """Client for the minimal relay service. stdlib urllib on purpose — the
+    relay API is four endpoints and not worth a dependency."""
+
+    def __init__(self, base_url: str):
+        self.base = base_url.rstrip("/")
+
+    def _request(self, method: str, path: str, body: bytes | None = None) -> bytes | None:
+        req = urllib.request.Request(self.base + path, data=body, method=method,
+                                     headers={"Content-Type": "application/octet-stream"})
+        try:
+            with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT_S) as resp:
+                return resp.read()
+        except urllib.error.HTTPError as exc:
+            if exc.code == 404:
+                return None
+            raise
+
+    def put_slot(self, slot: str, blob: bytes) -> None:
+        self._request("PUT", f"/slot/{slot}", blob)
+
+    def get_slot(self, slot: str) -> bytes | None:
+        return self._request("GET", f"/slot/{slot}")
+
+    def post_mail(self, address: str, blob: bytes) -> None:
+        self._request("POST", f"/mail/{address}", blob)
+
+    def fetch_mail(self, address: str) -> list[bytes]:
+        raw = self._request("GET", f"/mail/{address}?consume=1")
+        if not raw:
+            return []
+        items = json.loads(raw)
+        import base64
+        return [base64.b64decode(i) for i in items]
+
+
+def from_env(env: dict) -> Transport | None:
+    """Relay URL wins; a shared directory is the zero-infra fallback."""
+    url = env.get("SESSION_RECALL_RELAY_URL")
+    if url:
+        return HttpRelayTransport(url)
+    root = env.get("SESSION_RECALL_SHARE_TRANSPORT_DIR")
+    if root:
+        return FileTransport(Path(root))
+    return None

--- a/src/session_recall/share/trust.py
+++ b/src/session_recall/share/trust.py
@@ -1,0 +1,101 @@
+"""Trust store: who may ask, and which projects are shareable at all.
+
+Written only by the CLI in a human's hands. The MCP server and the (future)
+answer worker get read access at most — an LLM must be physically unable to
+enroll a peer or widen scope (gate §2: tokens are made by people).
+
+mode is stored per peer but v1 enforces `accept` everywhere: the bypass ramp
+(scanner hard-block, per-peer scope, volume caps) is deliberately not built yet
+— see the decision doc's "Отвергли".
+"""
+
+import json
+import os
+import stat
+import time
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+
+TRUST_FILE = "trust.json"
+
+
+@dataclass
+class Peer:
+    name: str
+    address: str
+    sign_pk: str
+    box_pk: str
+    mode: str = "accept"
+    added_at: float = 0.0
+    revoked: bool = False
+
+
+@dataclass
+class _State:
+    peers: list = field(default_factory=list)
+    allowed_projects: list = field(default_factory=list)
+
+
+class TrustStore:
+    def __init__(self, path: Path):
+        self.path = path
+        if path.exists():
+            raw = json.loads(path.read_text())
+            self._state = _State(
+                peers=[Peer(**p) for p in raw.get("peers", [])],
+                allowed_projects=list(raw.get("allowed_projects", [])))
+        else:
+            self._state = _State()
+
+    def _save(self) -> None:
+        """Atomic + 0600: a half-written trust store must never exist, and the
+        peer list is nobody's business but the owner's."""
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self.path.with_suffix(".tmp")
+        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+                     stat.S_IRUSR | stat.S_IWUSR)
+        with os.fdopen(fd, "w") as f:
+            json.dump({"peers": [asdict(p) for p in self._state.peers],
+                       "allowed_projects": self._state.allowed_projects}, f, indent=2)
+        os.replace(tmp, self.path)
+
+    # -- peers ---------------------------------------------------------------
+    def add(self, peer: Peer) -> None:
+        if self.get_by_address(peer.address, include_revoked=True):
+            raise ValueError(f"peer with address {peer.address} already present")
+        peer.added_at = peer.added_at or time.time()
+        self._state.peers.append(peer)
+        self._save()
+
+    def peers(self, include_revoked: bool = False) -> list[Peer]:
+        return [p for p in self._state.peers if include_revoked or not p.revoked]
+
+    def get_by_address(self, address: str, include_revoked: bool = False) -> Peer | None:
+        for p in self._state.peers:
+            if p.address == address and (include_revoked or not p.revoked):
+                return p
+        return None
+
+    def revoke(self, name_or_address: str) -> Peer | None:
+        """Flag, don't delete: a revoked key must stay known so its envelopes
+        keep failing closed instead of looking like a stranger's."""
+        for p in self._state.peers:
+            if not p.revoked and name_or_address in (p.name, p.address):
+                p.revoked = True
+                self._save()
+                return p
+        return None
+
+    # -- shareable scope -----------------------------------------------------
+    def allowed_projects(self) -> list[str]:
+        return list(self._state.allowed_projects)
+
+    def allow_project(self, project: str) -> None:
+        if project not in self._state.allowed_projects:
+            self._state.allowed_projects.append(project)
+            self._save()
+
+    def disallow_project(self, project: str) -> None:
+        if project in self._state.allowed_projects:
+            self._state.allowed_projects.remove(project)
+            self._save()

--- a/tests/test_share_cli.py
+++ b/tests/test_share_cli.py
@@ -1,0 +1,92 @@
+"""End-to-end ceremony through the real CLI with a FileTransport: two homes,
+one shared folder, both sides finish with each other in their trust stores."""
+
+import pytest
+
+from session_recall import cli, config
+
+
+@pytest.fixture
+def homes(tmp_path, monkeypatch):
+    monkeypatch.setenv("SESSION_RECALL_SHARE_TRANSPORT_DIR", str(tmp_path / "relay"))
+    monkeypatch.delenv("SESSION_RECALL_RELAY_URL", raising=False)
+
+    def as_user(home):
+        monkeypatch.setattr(config, "DATA_DIR", tmp_path / home)
+    return as_user
+
+
+def _run(argv):
+    return cli.main(argv) or 0
+
+
+def test_full_ceremony(homes, capsys):
+    homes("maxim")
+    assert _run(["share", "init", "maxim"]) == 0
+    assert _run(["share", "invite"]) == 0
+    out = capsys.readouterr().out
+    code = next(line.strip() for line in out.splitlines()
+                if line.strip() and "-" in line and " " not in line.strip())
+
+    homes("egor")
+    assert _run(["share", "init", "egor"]) == 0
+    assert _run(["share", "join", code]) == 0
+    sas_egor = capsys.readouterr().out
+    assert _run(["share", "trust"]) == 0
+
+    homes("maxim")
+    assert _run(["share", "complete"]) == 0
+    sas_maxim = capsys.readouterr().out
+    assert _run(["share", "trust"]) == 0
+
+    sas = [l for l in sas_egor.splitlines() if "SAS code:" in l]
+    assert sas and sas == [l for l in sas_maxim.splitlines() if "SAS code:" in l]
+
+    assert _run(["share", "devices"]) == 0
+    assert "egor" in capsys.readouterr().out
+
+    homes("egor")
+    assert _run(["share", "devices"]) == 0
+    assert "maxim" in capsys.readouterr().out
+
+
+def test_join_with_bad_code_fails_cleanly(homes, capsys):
+    homes("egor")
+    _run(["share", "init", "egor"])
+    assert _run(["share", "join", "zzzz-zzzz"]) == 1
+    assert "pairing failed" in capsys.readouterr().out
+
+
+def test_trust_requires_pairing(homes, capsys):
+    homes("maxim")
+    _run(["share", "init", "maxim"])
+    assert _run(["share", "trust"]) == 1
+    assert "nothing to trust" in capsys.readouterr().out
+
+
+def test_revoke_and_allow(homes, capsys):
+    homes("maxim")
+    _run(["share", "init", "maxim"])
+
+    assert _run(["share", "allow"]) == 0
+    assert "default deny" in capsys.readouterr().out
+    assert _run(["share", "allow", "session-recall"]) == 0
+    assert _run(["share", "allow"]) == 0
+    assert "session-recall" in capsys.readouterr().out
+    assert _run(["share", "allow", "session-recall", "--remove"]) == 0
+
+    assert _run(["share", "revoke", "nobody"]) == 1
+
+
+def test_commands_without_identity_point_to_init(homes, capsys):
+    homes("maxim")
+    assert _run(["share", "devices"]) == 1
+    assert "share init" in capsys.readouterr().out
+
+
+def test_no_transport_hint(homes, capsys, monkeypatch):
+    monkeypatch.delenv("SESSION_RECALL_SHARE_TRANSPORT_DIR", raising=False)
+    homes("maxim")
+    _run(["share", "init", "maxim"])
+    assert _run(["share", "invite"]) == 1
+    assert "no transport configured" in capsys.readouterr().out

--- a/tests/test_share_envelope.py
+++ b/tests/test_share_envelope.py
@@ -1,0 +1,166 @@
+import json
+
+import pytest
+
+from session_recall.share import envelope
+from session_recall.share import identity as identity_mod
+from session_recall.share.crypto import b64, unb64, canonical
+from session_recall.share.envelope import ShareState, open_incoming, make_request, make_response
+from session_recall.share.trust import Peer, TrustStore
+
+
+@pytest.fixture
+def world(tmp_path):
+    """maxim and egor, mutually trusted."""
+    maxim = identity_mod.create(tmp_path / "a", "maxim")
+    egor = identity_mod.create(tmp_path / "b", "egor")
+    maxim_trust = TrustStore(tmp_path / "a" / "trust.json")
+    egor_trust = TrustStore(tmp_path / "b" / "trust.json")
+    maxim_trust.add(_peer(egor))
+    egor_trust.add(_peer(maxim))
+    return maxim, egor, maxim_trust, egor_trust, ShareState(tmp_path / "a" / "state.json")
+
+
+def _peer(ident) -> Peer:
+    b = ident.public_bundle()
+    return Peer(name=b["name"], address=b["address"],
+                sign_pk=b["sign_pk"], box_pk=b["box_pk"])
+
+
+def test_request_roundtrip(world):
+    maxim, egor, maxim_trust, _, state = world
+    raw = make_request(egor, _peer(maxim), "how did you fix the CI?", task="debug")
+    got = open_incoming(maxim, maxim_trust, state, raw)
+    assert got is not None
+    assert got.kind == "req"
+    assert got.body == {"question": "how did you fix the CI?", "task": "debug"}
+    assert got.peer.name == "egor"
+
+
+def test_response_roundtrip(world):
+    maxim, egor, maxim_trust, egor_trust, state = world
+    req = make_request(egor, _peer(maxim), "q")
+    got = open_incoming(maxim, maxim_trust, state, req)
+    resp = make_response(maxim, _peer(egor), "the answer", in_reply_to=got.nonce)
+    egor_state = ShareState(maxim_trust.path.parent / "egor-state.json")
+    got_resp = open_incoming(egor, egor_trust, egor_state, resp)
+    assert got_resp.kind == "resp"
+    assert got_resp.body == {"text": "the answer"}
+    assert got_resp.in_reply_to == got.nonce
+
+
+def test_unknown_sender_dropped(world, tmp_path):
+    maxim, _, maxim_trust, _, state = world
+    mallory = identity_mod.create(tmp_path / "m", "mallory")
+    raw = make_request(mallory, _peer(maxim), "hi")
+    assert open_incoming(maxim, maxim_trust, state, raw) is None
+
+
+def test_revoked_sender_dropped(world):
+    maxim, egor, maxim_trust, _, state = world
+    maxim_trust.revoke("egor")
+    raw = make_request(egor, _peer(maxim), "q")
+    assert open_incoming(maxim, maxim_trust, state, raw) is None
+
+
+def test_wrong_recipient_dropped(world, tmp_path):
+    """Envelope addressed to someone else must not open even with valid crypto."""
+    maxim, egor, maxim_trust, _, state = world
+    other = identity_mod.create(tmp_path / "o", "other")
+    raw = make_request(egor, _peer(other), "q")
+    assert open_incoming(maxim, maxim_trust, state, raw) is None
+
+
+def test_tampered_payload_dropped(world):
+    maxim, egor, maxim_trust, _, state = world
+    env = json.loads(make_request(egor, _peer(maxim), "q"))
+    env["ts"] = env["ts"] + 1  # any signed-field change must kill the signature
+    assert open_incoming(maxim, maxim_trust, state,
+                         json.dumps(env).encode()) is None
+
+
+def test_signature_from_wrong_key_dropped(world, tmp_path):
+    maxim, egor, maxim_trust, _, state = world
+    mallory = identity_mod.create(tmp_path / "m", "mallory")
+    env = json.loads(make_request(egor, _peer(maxim), "q"))
+    env.pop("sig")
+    env["from"] = egor.address  # claims to be egor…
+    sig = mallory.signing_key.sign(canonical(env)).signature  # …signed by mallory
+    env["sig"] = b64(sig)
+    assert open_incoming(maxim, maxim_trust, state,
+                         json.dumps(env).encode()) is None
+
+
+def test_stale_timestamp_dropped(world):
+    maxim, egor, maxim_trust, _, state = world
+    raw = make_request(egor, _peer(maxim), "q")
+    now = json.loads(raw)["ts"] + envelope.REQ_TTL_S + 1
+    assert open_incoming(maxim, maxim_trust, state, raw, now=now) is None
+
+
+def test_replay_dropped(world):
+    maxim, egor, maxim_trust, _, state = world
+    raw = make_request(egor, _peer(maxim), "q")
+    assert open_incoming(maxim, maxim_trust, state, raw) is not None
+    assert open_incoming(maxim, maxim_trust, state, raw) is None
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    """Simulated wall clock driving BOTH envelope creation (ts) and the inbound
+    gate (now) — otherwise every simulated-time test trips the staleness check."""
+    state = {"t": 1_800_000_000.0}
+    monkeypatch.setattr(envelope.time, "time", lambda: state["t"])
+
+    def advance(dt: float) -> float:
+        state["t"] += dt
+        return state["t"]
+    return advance
+
+
+def test_rate_limit_per_minute(world, clock):
+    maxim, egor, maxim_trust, _, state = world
+    for i in range(envelope.RATE_PER_MIN):
+        raw = make_request(egor, _peer(maxim), f"q{i}")
+        assert open_incoming(maxim, maxim_trust, state, raw, now=clock(1)) is not None
+    raw = make_request(egor, _peer(maxim), "one too many")
+    assert open_incoming(maxim, maxim_trust, state, raw, now=clock(1)) is None
+    # …but the window slides: a minute later requests flow again
+    raw = make_request(egor, _peer(maxim), "later")
+    assert open_incoming(maxim, maxim_trust, state, raw, now=clock(60)) is not None
+
+
+def test_rate_limit_per_day(world, clock):
+    maxim, egor, maxim_trust, _, state = world
+    for i in range(envelope.RATE_PER_DAY):
+        # spread far apart so the minute window never trips
+        clock(120)
+        raw = make_request(egor, _peer(maxim), f"q{i}")
+        assert open_incoming(maxim, maxim_trust, state, raw, now=clock(0)) is not None
+    raw = make_request(egor, _peer(maxim), "pump")
+    assert open_incoming(maxim, maxim_trust, state, raw, now=clock(120)) is None
+
+
+def test_responses_not_rate_limited(world, clock):
+    """Rate caps guard the asking side; replies to our own questions must not
+    starve just because the peer answered a burst of them."""
+    maxim, egor, maxim_trust, egor_trust, _ = world
+    egor_state = ShareState(egor_trust.path.parent / "state.json")
+    for i in range(envelope.RATE_PER_MIN + 2):
+        resp = make_response(maxim, _peer(egor), f"a{i}", in_reply_to=f"n{i}")
+        assert open_incoming(egor, egor_trust, egor_state, resp, now=clock(1)) is not None
+
+
+def test_garbage_bytes_dropped(world):
+    maxim, _, maxim_trust, _, state = world
+    for garbage in (b"", b"\xff\xfe", b"[]", b"{}", b'{"v":2}'):
+        assert open_incoming(maxim, maxim_trust, state, garbage) is None
+
+
+def test_state_survives_reload(world, tmp_path):
+    """Replay protection must hold across process restarts."""
+    maxim, egor, maxim_trust, _, state = world
+    raw = make_request(egor, _peer(maxim), "q")
+    assert open_incoming(maxim, maxim_trust, state, raw) is not None
+    reloaded = ShareState(state.path)
+    assert open_incoming(maxim, maxim_trust, reloaded, raw) is None

--- a/tests/test_share_pairing.py
+++ b/tests/test_share_pairing.py
@@ -1,0 +1,86 @@
+import time
+
+import pytest
+
+from session_recall.share import identity as identity_mod
+from session_recall.share import pairing
+from session_recall.share.pairing import PairingError
+from session_recall.share.transport import InMemoryTransport
+
+
+@pytest.fixture
+def two_sides(tmp_path):
+    a_dir, b_dir = tmp_path / "a", tmp_path / "b"
+    return (identity_mod.create(a_dir, "maxim"), a_dir,
+            identity_mod.create(b_dir, "egor"), b_dir,
+            InMemoryTransport())
+
+
+def test_happy_path_same_sas_both_sides(two_sides):
+    a, a_dir, b, b_dir, t = two_sides
+    code = pairing.start_invite(a, t, a_dir)
+    joined = pairing.join(b, t, b_dir, code)
+    completed = pairing.complete_invite(a, t, a_dir)
+
+    assert joined.sas == completed.sas
+    assert joined.bundle["name"] == "maxim"
+    assert completed.bundle["name"] == "egor"
+    assert joined.bundle["sign_pk"] == a.sign_pk_b64
+    # both sides parked a pending peer for the explicit `trust` step
+    assert pairing.pending_peer(a_dir)["bundle"]["name"] == "egor"
+    assert pairing.pending_peer(b_dir)["bundle"]["name"] == "maxim"
+
+
+def test_wrong_code_rejected(two_sides):
+    a, a_dir, b, b_dir, t = two_sides
+    code = pairing.start_invite(a, t, a_dir)
+    # same slot id, different key: MAC must fail, not decode garbage
+    tampered = code[:-4] + ("aaaa" if not code.endswith("aaaa") else "bbbb")
+    with pytest.raises(PairingError):
+        pairing.join(b, t, b_dir, tampered)
+
+
+def test_unknown_invite_id(two_sides):
+    _, _, b, b_dir, t = two_sides
+    with pytest.raises(PairingError, match="not found"):
+        pairing.join(b, t, b_dir, "a" * 60)  # well-formed code, nonexistent slot
+
+
+def test_garbage_code_rejected(two_sides):
+    _, _, b, b_dir, t = two_sides
+    with pytest.raises(PairingError):
+        pairing.join(b, t, b_dir, "not-a-code")
+
+
+def test_expired_invite(two_sides, monkeypatch):
+    a, a_dir, b, b_dir, t = two_sides
+    code = pairing.start_invite(a, t, a_dir)
+    real = time.time
+    monkeypatch.setattr(pairing.time, "time", lambda: real() + pairing.INVITE_TTL_S + 5)
+    with pytest.raises(PairingError, match="expired"):
+        pairing.join(b, t, b_dir, code)
+
+
+def test_complete_before_join(two_sides):
+    a, a_dir, _, _, t = two_sides
+    pairing.start_invite(a, t, a_dir)
+    with pytest.raises(PairingError, match="not joined yet"):
+        pairing.complete_invite(a, t, a_dir)
+
+
+def test_complete_without_invite(two_sides):
+    a, a_dir, _, _, t = two_sides
+    with pytest.raises(PairingError, match="no pending invite"):
+        pairing.complete_invite(a, t, a_dir)
+
+
+def test_identity_files_are_private(two_sides):
+    _, a_dir, _, _, _ = two_sides
+    mode = (a_dir / "identity.json").stat().st_mode
+    assert mode & 0o077 == 0, "identity must be 0600"
+
+
+def test_identity_create_refuses_overwrite(tmp_path):
+    identity_mod.create(tmp_path, "maxim")
+    with pytest.raises(FileExistsError):
+        identity_mod.create(tmp_path, "maxim-again")


### PR DESCRIPTION
Первый кусок реализации [спеки v1](docs/decisions/2026-07-30-p2p-sharing-v1-security-gate.md) — фундамент без LLM:

- **identity**: Ed25519 (подпись) + X25519 (box) + адрес 128 бит base32; файлы 0600, вне index DB
- **pairing-церемония**: `share invite → join <code> → complete` через secretbox под одноразовым ключом из invite-кода (relay не может ни читать, ни подменить), SAS у обеих сторон, и **отдельный человеческий шаг** `share trust` — автоматика не может проскочить сверку
- **trust store**: peers c mode (v1 — только accept), revoke (флаг, не удаление — конверты отозванного падают как fail-closed), shareable-проекты (default deny)
- **конверты**: подпись + E2E box, единый входной гейт `open_incoming` — silent drop на всё: неизвестный/отозванный ключ, битая подпись, stale ts, replay, 3/мин + 30/день (rate — после подписи, чтобы чужак не сжигал квоту пира)
- **транспорты** — недоверенные носители блобов: InMemory (тесты), FileTransport (общая папка), HttpRelay-клиент (сервер — PR 2)
- CLI: `session-recall share init/invite/join/complete/trust/devices/revoke/allow`
- 29 новых тестов; вся сюита 173 passed локально

Крипто — только libsodium (PyNaCl). MCP-сервер не получил ни одной новой тулзы — trust-мутации физически недоступны LLM (гейт §2).

Отступление от спеки: адрес в base32 (stdlib), не base58 — свойство то же (128 бит), зависимостью меньше.

Далее: PR 2 relay-сервер → PR 3 воркер-клетка → PR 4 TG-апрув.

🤖 Generated with [Claude Code](https://claude.com/claude-code)