### PR TITLE
feat(share): relay server — blind blob store (gate v1, PR 2/4)

### DIFF
--- a/src/session_recall/share/cli.py
+++ b/src/session_recall/share/cli.py
@@ -37,6 +37,10 @@ def add_parser(sub) -> None:
     ap = ssub.add_parser("allow", help="mark a project shareable (no arg: list)")
     ap.add_argument("project", nargs="?")
     ap.add_argument("--remove", action="store_true")
+    rlp = ssub.add_parser("relay", help="run the relay server (blind blob store)")
+    rlp.add_argument("--port", type=int, default=8787)
+    rlp.add_argument("--data", default=None,
+                     help="storage dir (default: <data-dir>/share-relay)")
 
 
 def _sas_block(res: pairing.PairingResult) -> str:
@@ -49,6 +53,12 @@ def _sas_block(res: pairing.PairingResult) -> str:
 def run(args: argparse.Namespace) -> int:
     sdir = config.DATA_DIR / "share"
     cmd = args.share_cmd
+
+    if cmd == "relay":
+        from pathlib import Path
+        from .relay import serve
+        serve(args.port, Path(args.data) if args.data else config.DATA_DIR / "share-relay")
+        return 0
 
     if cmd == "init":
         try:
@@ -68,7 +78,7 @@ def run(args: argparse.Namespace) -> int:
     trust = TrustStore(sdir / "trust.json")
 
     if cmd in ("invite", "join", "complete"):
-        transport = from_env(os.environ)
+        transport = from_env(os.environ, identity=ident)
         if transport is None:
             print(_TRANSPORT_HINT)
             return 1

--- a/src/session_recall/share/relay.py
+++ b/src/session_recall/share/relay.py
@@ -1,0 +1,191 @@
+"""Minimal relay: dumb, blind, disposable.
+
+It stores two kinds of opaque blobs — pairing slots and mail envelopes — and
+can read neither (secretbox/box seal them client-side). Losing the relay loses
+nothing but undelivered mail; trust never depends on it (gate: transports are
+untrusted).
+
+What it still must defend, because crypto upstream cannot:
+- **mail theft-by-consume**: fetching an inbox destroys it, so fetch requires
+  an Ed25519 signature over a fresh timestamp. The first authenticated fetch
+  binds address→key (first-write-wins; addresses are 128 random bits, so a
+  squatter would have to guess the address before its owner's first fetch).
+- **garbage floods**: size/count caps and TTLs. POST stays anonymous on
+  purpose — authenticating senders would hand the relay the social graph,
+  and the receiver's own gate drops junk anyway.
+- **metadata hygiene**: requests are logged as method+status only, never the
+  path — the path is the address.
+
+stdlib http.server on purpose: four routes do not justify a framework.
+"""
+
+import json
+import re
+import secrets
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import urlparse
+
+from nacl.exceptions import CryptoError
+from nacl.signing import VerifyKey
+
+from .crypto import b64, unb64, canonical
+
+MAX_BLOB = 64 * 1024
+MAX_MAILBOX = 100
+SLOT_TTL_S = 3600
+MAIL_TTL_S = 7 * 86400
+FETCH_SIG_WINDOW_S = 60
+
+_NAME_RE = re.compile(r"^[a-z0-9-]{1,64}$")
+
+
+class RelayStore:
+    """Filesystem-backed so a restart drops nothing. Layout mirrors
+    FileTransport (slots/, mail/<addr>/) plus addrs.json for fetch auth."""
+
+    def __init__(self, root: Path, clock=time.time):
+        self.root = Path(root)
+        self.clock = clock
+        self._addrs_path = self.root / "addrs.json"
+        self.addrs: dict[str, str] = (
+            json.loads(self._addrs_path.read_text()) if self._addrs_path.exists() else {})
+
+    def _prune(self, directory: Path, ttl: float) -> None:
+        if not directory.is_dir():
+            return
+        now = self.clock()
+        for p in directory.iterdir():
+            if now - p.stat().st_mtime > ttl:
+                p.unlink(missing_ok=True)
+
+    # -- slots ----------------------------------------------------------------
+    def put_slot(self, slot: str, blob: bytes) -> None:
+        d = self.root / "slots"
+        d.mkdir(parents=True, exist_ok=True)
+        self._prune(d, SLOT_TTL_S)
+        (d / slot).write_bytes(blob)
+
+    def get_slot(self, slot: str) -> bytes | None:
+        p = self.root / "slots" / slot
+        self._prune(self.root / "slots", SLOT_TTL_S)
+        return p.read_bytes() if p.exists() else None
+
+    # -- mail -----------------------------------------------------------------
+    def post_mail(self, address: str, blob: bytes) -> None:
+        d = self.root / "mail" / address
+        d.mkdir(parents=True, exist_ok=True)
+        self._prune(d, MAIL_TTL_S)
+        if len(list(d.iterdir())) >= MAX_MAILBOX:
+            return  # full mailbox drops silently; the cap is anti-flood
+        (d / f"{int(self.clock() * 1000):015d}-{secrets.token_hex(4)}").write_bytes(blob)
+
+    def consume_mail(self, address: str) -> list[bytes]:
+        d = self.root / "mail" / address
+        if not d.is_dir():
+            return []
+        self._prune(d, MAIL_TTL_S)
+        out = []
+        for p in sorted(d.iterdir()):
+            out.append(p.read_bytes())
+            p.unlink()
+        return out
+
+    # -- fetch auth -----------------------------------------------------------
+    def check_fetch(self, address: str, pk_b64: str, ts: float, sig_b64: str) -> bool:
+        if abs(self.clock() - ts) > FETCH_SIG_WINDOW_S:
+            return False
+        known = self.addrs.get(address)
+        pk = known or pk_b64          # first fetch enrolls, later ones must match
+        try:
+            VerifyKey(unb64(pk)).verify(
+                canonical({"action": "fetch", "address": address, "ts": ts}),
+                unb64(sig_b64))
+        except (CryptoError, ValueError, TypeError):
+            return False
+        if known is None:
+            self.addrs[address] = pk_b64
+            self.root.mkdir(parents=True, exist_ok=True)
+            self._addrs_path.write_text(json.dumps(self.addrs))
+        return True
+
+
+def fetch_auth_headers(identity, address: str) -> dict[str, str]:
+    """Client side of check_fetch — kept next to it so they cannot drift."""
+    ts = time.time()
+    sig = identity.signing_key.sign(
+        canonical({"action": "fetch", "address": address, "ts": ts})).signature
+    return {"X-Share-Pk": identity.sign_pk_b64, "X-Share-Ts": str(ts),
+            "X-Share-Sig": b64(sig)}
+
+
+def make_handler(store: RelayStore):
+    class Handler(BaseHTTPRequestHandler):
+        server_version = "session-recall-relay"
+
+        def log_message(self, fmt, *args):  # method+status only; paths are addresses
+            print(f"{self.command} -> {getattr(self, '_status', '?')}", flush=True)
+
+        def _reply(self, code: int, body: bytes = b"") -> None:
+            self._status = code
+            self.send_response(code)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def _read_body(self) -> bytes | None:
+            length = int(self.headers.get("Content-Length") or 0)
+            if length > MAX_BLOB:
+                return None
+            return self.rfile.read(length)
+
+        def _name(self, prefix: str) -> str | None:
+            path = urlparse(self.path).path
+            if not path.startswith(prefix):
+                return None
+            name = path[len(prefix):]
+            return name if _NAME_RE.match(name) else None
+
+        def do_PUT(self):
+            slot = self._name("/slot/")
+            body = self._read_body()
+            if slot is None or body is None:
+                return self._reply(413 if body is None else 404)
+            store.put_slot(slot, body)
+            self._reply(200)
+
+        def do_POST(self):
+            address = self._name("/mail/")
+            body = self._read_body()
+            if address is None or body is None:
+                return self._reply(413 if body is None else 404)
+            store.post_mail(address, body)
+            self._reply(200)  # always 200: existence of inboxes is not disclosed
+
+        def do_GET(self):
+            slot = self._name("/slot/")
+            if slot is not None:
+                blob = store.get_slot(slot)
+                return self._reply(404) if blob is None else self._reply(200, blob)
+            address = self._name("/mail/")
+            if address is not None:
+                try:
+                    ok = store.check_fetch(
+                        address, self.headers.get("X-Share-Pk", ""),
+                        float(self.headers.get("X-Share-Ts", "0")),
+                        self.headers.get("X-Share-Sig", ""))
+                except ValueError:
+                    ok = False
+                # bad auth and empty inbox are indistinguishable on purpose
+                items = store.consume_mail(address) if ok else []
+                return self._reply(200, json.dumps([b64(i) for i in items]).encode())
+            self._reply(404)
+
+    return Handler
+
+
+def serve(port: int, data_dir: Path) -> None:
+    server = ThreadingHTTPServer(("0.0.0.0", port), make_handler(RelayStore(data_dir)))
+    print(f"relay listening on :{port}, data in {data_dir}", flush=True)
+    server.serve_forever()

--- a/src/session_recall/share/transport.py
+++ b/src/session_recall/share/transport.py
@@ -76,14 +76,21 @@ class FileTransport:
 
 class HttpRelayTransport:
     """Client for the minimal relay service. stdlib urllib on purpose — the
-    relay API is four endpoints and not worth a dependency."""
+    relay API is four endpoints and not worth a dependency.
 
-    def __init__(self, base_url: str):
+    `identity` is needed for fetch_mail only: consuming an inbox is
+    destructive, so the relay demands a signature (see relay.check_fetch);
+    everything else stays anonymous."""
+
+    def __init__(self, base_url: str, identity=None):
         self.base = base_url.rstrip("/")
+        self.identity = identity
 
-    def _request(self, method: str, path: str, body: bytes | None = None) -> bytes | None:
+    def _request(self, method: str, path: str, body: bytes | None = None,
+                 headers: dict | None = None) -> bytes | None:
+        all_headers = {"Content-Type": "application/octet-stream", **(headers or {})}
         req = urllib.request.Request(self.base + path, data=body, method=method,
-                                     headers={"Content-Type": "application/octet-stream"})
+                                     headers=all_headers)
         try:
             with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT_S) as resp:
                 return resp.read()
@@ -102,7 +109,9 @@ class HttpRelayTransport:
         self._request("POST", f"/mail/{address}", blob)
 
     def fetch_mail(self, address: str) -> list[bytes]:
-        raw = self._request("GET", f"/mail/{address}?consume=1")
+        from .relay import fetch_auth_headers
+        headers = fetch_auth_headers(self.identity, address) if self.identity else {}
+        raw = self._request("GET", f"/mail/{address}", headers=headers)
         if not raw:
             return []
         items = json.loads(raw)
@@ -110,11 +119,11 @@ class HttpRelayTransport:
         return [base64.b64decode(i) for i in items]
 
 
-def from_env(env: dict) -> Transport | None:
+def from_env(env: dict, identity=None) -> Transport | None:
     """Relay URL wins; a shared directory is the zero-infra fallback."""
     url = env.get("SESSION_RECALL_RELAY_URL")
     if url:
-        return HttpRelayTransport(url)
+        return HttpRelayTransport(url, identity=identity)
     root = env.get("SESSION_RECALL_SHARE_TRANSPORT_DIR")
     if root:
         return FileTransport(Path(root))

--- a/tests/test_share_relay.py
+++ b/tests/test_share_relay.py
@@ -1,0 +1,138 @@
+"""The relay is exercised over real HTTP: ThreadingHTTPServer on an ephemeral
+port, the actual HttpRelayTransport as the client."""
+
+import threading
+import time
+import urllib.error
+from http.server import ThreadingHTTPServer
+
+import pytest
+
+from session_recall.share import identity as identity_mod
+from session_recall.share import pairing, relay
+from session_recall.share.envelope import ShareState, make_request, open_incoming
+from session_recall.share.transport import HttpRelayTransport
+from session_recall.share.trust import Peer, TrustStore
+
+
+@pytest.fixture
+def server(tmp_path):
+    clockbox = {"t": time.time()}
+    store = relay.RelayStore(tmp_path / "relay-data", clock=lambda: clockbox["t"])
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), relay.make_handler(store))
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    yield f"http://127.0.0.1:{httpd.server_address[1]}", clockbox
+    httpd.shutdown()
+
+
+@pytest.fixture
+def users(tmp_path):
+    maxim = identity_mod.create(tmp_path / "maxim", "maxim")
+    egor = identity_mod.create(tmp_path / "egor", "egor")
+    return maxim, egor
+
+
+def test_slot_roundtrip_and_miss(server, users):
+    url, _ = server
+    t = HttpRelayTransport(url)
+    t.put_slot("pair-a-abc", b"sealed-bundle")
+    assert t.get_slot("pair-a-abc") == b"sealed-bundle"
+    assert t.get_slot("pair-a-nope") is None
+
+
+def test_invalid_slot_name_rejected(server):
+    url, _ = server
+    t = HttpRelayTransport(url)
+    assert t.get_slot("..%2f..%2fetc") is None
+
+
+def test_mail_requires_signature(server, users):
+    url, _ = server
+    maxim, egor = users
+    anon = HttpRelayTransport(url)                       # no identity
+    anon.post_mail(maxim.address, b"envelope-1")
+    assert anon.fetch_mail(maxim.address) == []          # unsigned fetch: silence
+    owner = HttpRelayTransport(url, identity=maxim)
+    assert owner.fetch_mail(maxim.address) == [b"envelope-1"]
+    assert owner.fetch_mail(maxim.address) == []         # consumed
+
+
+def test_wrong_key_cannot_steal_mail(server, users, tmp_path):
+    url, _ = server
+    maxim, egor = users
+    owner = HttpRelayTransport(url, identity=maxim)
+    assert owner.fetch_mail(maxim.address) == []         # first fetch binds the key
+    HttpRelayTransport(url).post_mail(maxim.address, b"secret-envelope")
+    mallory = identity_mod.create(tmp_path / "m", "mallory")
+    thief = HttpRelayTransport(url, identity=mallory)
+    assert thief.fetch_mail(maxim.address) == []         # wrong key: silence
+    assert owner.fetch_mail(maxim.address) == [b"secret-envelope"]  # still there
+
+
+def test_stale_fetch_signature_rejected(server, users, monkeypatch):
+    url, _ = server
+    maxim, _ = users
+    HttpRelayTransport(url).post_mail(maxim.address, b"envelope")
+    real = time.time
+    monkeypatch.setattr(relay.time, "time",
+                        lambda: real() - relay.FETCH_SIG_WINDOW_S - 5)
+    stale = HttpRelayTransport(url, identity=maxim)      # signs with skewed clock
+    assert stale.fetch_mail(maxim.address) == []
+    monkeypatch.undo()
+    assert HttpRelayTransport(url, identity=maxim).fetch_mail(
+        maxim.address) == [b"envelope"]
+
+
+def test_oversized_blob_rejected(server):
+    url, _ = server
+    t = HttpRelayTransport(url)
+    with pytest.raises(urllib.error.HTTPError):
+        t.put_slot("pair-a-big", b"x" * (relay.MAX_BLOB + 1))
+
+
+def test_mailbox_cap(server, users, monkeypatch):
+    url, _ = server
+    maxim, _ = users
+    monkeypatch.setattr(relay, "MAX_MAILBOX", 3)
+    anon = HttpRelayTransport(url)
+    for i in range(5):
+        anon.post_mail(maxim.address, f"e{i}".encode())
+    got = HttpRelayTransport(url, identity=maxim).fetch_mail(maxim.address)
+    # frozen test clock ⇒ identical name prefixes ⇒ order is not guaranteed;
+    # the cap keeps the first three accepted, overflow dropped silently
+    assert sorted(got) == [b"e0", b"e1", b"e2"]
+
+
+def test_slot_ttl(server):
+    url, clockbox = server
+    t = HttpRelayTransport(url)
+    t.put_slot("pair-a-old", b"sealed")
+    clockbox["t"] += relay.SLOT_TTL_S + 5
+    assert t.get_slot("pair-a-old") is None
+
+
+def test_full_ceremony_and_request_over_http(server, users, tmp_path):
+    """The whole v1 loop over a live relay: pair, trust, ask, gate."""
+    url, _ = server
+    maxim, egor = users
+    tm = HttpRelayTransport(url, identity=maxim)
+    te = HttpRelayTransport(url, identity=egor)
+    mdir, edir = tmp_path / "maxim", tmp_path / "egor"
+
+    code = pairing.start_invite(maxim, tm, mdir)
+    joined = pairing.join(egor, te, edir, code)
+    completed = pairing.complete_invite(maxim, tm, mdir)
+    assert joined.sas == completed.sas
+
+    maxim_trust = TrustStore(mdir / "trust.json")
+    b = joined.bundle  # egor trusts maxim's bundle; maxim trusts egor's
+    maxim_trust.add(Peer(name=completed.bundle["name"],
+                         address=completed.bundle["address"],
+                         sign_pk=completed.bundle["sign_pk"],
+                         box_pk=completed.bundle["box_pk"]))
+
+    te.post_mail(b["address"], make_request(egor, b, "how did you fix CI?"))
+    inbox = tm.fetch_mail(maxim.address)
+    assert len(inbox) == 1
+    got = open_incoming(maxim, maxim_trust, ShareState(mdir / "state.json"), inbox[0])
+    assert got is not None and got.body["question"] == "how did you fix CI?"


### PR DESCRIPTION
Relay из спеки: тупой, слепой, одноразовый. Хранит только запечатанные блобы (pairing-слоты + mail-конверты), прочитать не может by construction.

Что он всё же обязан защищать сам (крипта выше не покрывает):
- **кражу почты через consume**: fetch разрушающий, поэтому требует Ed25519-подпись свежего timestamp; первый аутентифицированный fetch привязывает address→key (first-write-wins на неугадываемом 128-битном адресе)
- **флуд**: лимиты 64KB/блоб, 100/ящик, TTL слотов 1ч и почты 7д
- **metadata-гигиену**: в логах только метод+статус, path не пишется — path это адрес; неверная подпись и пустой ящик неразличимы (200 `[]`)

POST анонимный сознательно: аутентификация отправителей отдала бы relay социальный граф, а мусор всё равно режет входной гейт получателя (PR 1).

Клиент: `HttpRelayTransport` подписывает fetch; `share relay --port 8787` поднимает сервер. 9 новых тестов гоняют настоящий HTTP на эфемерном порту, включая полную церемонию pairing + запрос через живой relay. Сюита: 182 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)