### PR TITLE
feat(share): caged answer worker + secret scanner (gate v1, PR 3/4)

### DIFF
--- a/src/session_recall/share/cli.py
+++ b/src/session_recall/share/cli.py
@@ -41,6 +41,12 @@ def add_parser(sub) -> None:
     rlp.add_argument("--port", type=int, default=8787)
     rlp.add_argument("--data", default=None,
                      help="storage dir (default: <data-dir>/share-relay)")
+    svp = ssub.add_parser("serve", help="poll inbox, build candidate answers")
+    svp.add_argument("--once", action="store_true", help="single sweep, then exit")
+    svp.add_argument("--interval", type=int, default=30)
+    ssub.add_parser("pending", help="list candidates waiting for approval")
+    shp2 = ssub.add_parser("show", help="print one candidate in full")
+    shp2.add_argument("id")
 
 
 def _sas_block(res: pairing.PairingResult) -> str:
@@ -96,6 +102,65 @@ def run(args: argparse.Namespace) -> int:
         except PairingError as exc:
             print(f"pairing failed: {exc}")
             return 1
+        return 0
+
+    if cmd == "serve":
+        transport = from_env(os.environ, identity=ident)
+        if transport is None:
+            print(_TRANSPORT_HINT)
+            return 1
+        import time as _time
+        from .. import config as _config
+        from ..embed import make_embedder
+        from ..rerank import make_reranker
+        from ..retrieve import Recall
+        from ..store import Store
+        from .envelope import ShareState
+        from .worker import poll_once
+        store = Store(_config.DB_PATH)
+        recall = Recall(store, make_embedder(), make_reranker())
+        searcher = lambda q, k: recall.recall_search(q, k=k)
+        state = ShareState(sdir / "state.json")
+        try:
+            while True:
+                for cand in poll_once(ident, trust, state, transport, searcher, sdir):
+                    flags = f"  ⚠ {len(cand.findings)} secret flag(s)" if cand.findings else ""
+                    print(f"[{cand.id} v{cand.version}] {cand.peer_name}: "
+                          f"{cand.question[:80]}{flags}\n"
+                          f"  review: session-recall share show {cand.id}")
+                if args.once:
+                    return 0
+                _time.sleep(args.interval)
+        finally:
+            store.close()
+
+    if cmd == "pending":
+        from .worker import list_pending
+        cands = list_pending(sdir)
+        if not cands:
+            print("no pending candidates")
+            return 0
+        for c in cands:
+            flags = f"  ⚠ {len(c.findings)}" if c.findings else ""
+            print(f"{c.id} v{c.version}  {c.peer_name}  {c.question[:70]}{flags}")
+        return 0
+
+    if cmd == "show":
+        from .worker import load_candidate
+        cand = load_candidate(sdir, args.id)
+        if cand is None:
+            print(f"no candidate {args.id!r}")
+            return 1
+        print(f"id: {cand.id}   version: {cand.version}   status: {cand.status}\n"
+              f"from: {cand.peer_name} ({cand.peer_address})\n"
+              f"question: {cand.question}")
+        if cand.task:
+            print(f'stated task (sender text, unverified): "{cand.task}"')
+        if cand.findings:
+            print("\n⚠ SECRET FLAGS — look closely before approving:")
+            for f in cand.findings:
+                print(f"  - {f['kind']}: {f['excerpt']}")
+        print(f"\n--- candidate answer (v{cand.version}) ---\n{cand.text}")
         return 0
 
     if cmd == "trust":

--- a/src/session_recall/share/scanner.py
+++ b/src/session_recall/share/scanner.py
@@ -1,0 +1,45 @@
+"""Secret scanner for outgoing candidates — dumb regexes on purpose.
+
+The gate's reasoning (§ превью/сканер): an LLM classifier would be one more
+prompt-injectable surface, while key formats are rigid strings. This is a
+tripwire, not a guarantee — its job is to catch the retrieval accidents
+(an env dump sitting next to the deploy discussion) and to survive any text
+an injection can compose. Findings never block by themselves in v1; they are
+flags the owner sees before approving.
+"""
+
+import re
+from dataclasses import dataclass
+
+_PATTERNS: list[tuple[str, re.Pattern]] = [
+    ("aws-access-key", re.compile(r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b")),
+    ("openai-key", re.compile(r"\bsk-[A-Za-z0-9_-]{20,}\b")),
+    ("anthropic-key", re.compile(r"\bsk-ant-[A-Za-z0-9_-]{20,}\b")),
+    ("github-token", re.compile(r"\bgh[pousr]_[A-Za-z0-9]{36,}\b")),
+    ("gitlab-token", re.compile(r"\bglpat-[A-Za-z0-9_-]{20,}\b")),
+    ("slack-token", re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b")),
+    ("jwt", re.compile(r"\beyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b")),
+    ("private-key-pem", re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----")),
+    ("telegram-bot-token", re.compile(r"\b\d{8,10}:[A-Za-z0-9_-]{35}\b")),
+    ("password-assignment", re.compile(   # [\w-]* prefix: POSTGRES_PASSWORD=…
+        r"(?i)\b[\w-]*(password|passwd|secret|api[_-]?key|token)\s*[=:]\s*\S{8,}")),
+    ("connection-string", re.compile(r"\b\w+://[^/\s:]+:[^@\s]+@[^\s]+")),
+]
+
+
+@dataclass
+class Finding:
+    kind: str
+    excerpt: str   # masked: enough to recognise, not enough to leak via the flag
+
+
+def _mask(match: str) -> str:
+    return match[:8] + "…" if len(match) > 8 else match
+
+
+def scan(text: str) -> list[Finding]:
+    findings = []
+    for kind, pattern in _PATTERNS:
+        for m in pattern.finditer(text):
+            findings.append(Finding(kind=kind, excerpt=_mask(m.group(0))))
+    return findings

--- a/src/session_recall/share/worker.py
+++ b/src/session_recall/share/worker.py
@@ -1,0 +1,151 @@
+"""The caged answerer: inbound envelopes → candidate answers, nothing else.
+
+Capability cage (gate §5): this module can (a) query the local index read-only
+through an injected `searcher` and (b) write candidate files into the outbox.
+It deliberately imports no send path, no approval channel, no shell, and no
+generic filesystem access — a prompt injection that fully controlled this code
+path could still only shape TEXT that lands in front of the owner. Sending is
+the send process's job after `/ok` (next PR); default-deny is structural.
+
+Two more gate invariants live here:
+- scope: only anchors from `share allow`-ed projects may enter a candidate
+  (default deny — empty allow-list means every answer comes back empty);
+- the worker leaves no transcripts, so nothing it processes can re-enter the
+  index and become a stored injection later.
+
+The candidate is assembled deterministically from recall anchors (snippets +
+provenance). An LLM summariser can later rewrite `text` — the envelope of the
+candidate (chunks, scanner flags, version hash, approval binding) stays as is.
+"""
+
+import json
+import os
+import secrets
+import stat
+import time
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Callable, Iterable
+
+from nacl.encoding import RawEncoder
+from nacl import hash as nacl_hash
+
+from .crypto import canonical
+from .envelope import Incoming, ShareState, open_incoming
+from .identity import Identity
+from .scanner import scan
+from .trust import TrustStore
+
+OUTBOX_DIR = "outbox"
+MAX_CHUNKS = 5
+MAX_SNIPPET = 700
+
+# searcher(query, k) -> anchors; injected so the worker can be driven by the
+# real Recall or by a stub in tests, and so this module never owns an embedder.
+Searcher = Callable[[str, int], Iterable]
+
+
+@dataclass
+class Candidate:
+    id: str
+    peer_name: str
+    peer_address: str
+    question: str
+    task: str
+    reply_nonce: str          # binds the eventual response to the exact request
+    created_at: float
+    text: str
+    chunks: list = field(default_factory=list)
+    findings: list = field(default_factory=list)
+    status: str = "pending"   # pending | approved | rejected | expired
+    version: str = ""         # /ok must quote this — approval of an exact blob
+
+    def compute_version(self) -> str:
+        digest = nacl_hash.blake2b(
+            canonical({"text": self.text, "chunks": self.chunks}),
+            digest_size=4, encoder=RawEncoder)
+        return digest.hex()
+
+
+def _outbox(share_dir: Path) -> Path:
+    d = share_dir / OUTBOX_DIR
+    d.mkdir(parents=True, exist_ok=True)
+    d.chmod(0o700)
+    return d
+
+
+def _write_candidate(share_dir: Path, cand: Candidate) -> Path:
+    path = _outbox(share_dir) / f"{cand.id}.json"
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+                 stat.S_IRUSR | stat.S_IWUSR)
+    with os.fdopen(fd, "w") as f:
+        json.dump(asdict(cand), f, indent=2, ensure_ascii=False)
+    return path
+
+
+def build_candidate(incoming: Incoming, searcher: Searcher,
+                    allowed_projects: list[str]) -> Candidate:
+    question = str(incoming.body.get("question", ""))[:2000]
+    task = str(incoming.body.get("task", ""))[:500]
+    anchors = list(searcher(question, 20)) if allowed_projects else []
+    picked = [a for a in anchors if a.project in allowed_projects][:MAX_CHUNKS]
+
+    chunks = [{"project": a.project, "session_id": a.session_id, "uuid": a.uuid,
+               "role": a.role, "snippet": a.snippet[:MAX_SNIPPET],
+               "score": a.score, "source": a.source} for a in picked]
+    if chunks:
+        text = "\n\n".join(f"[{c['project']} · {c['session_id'][:8]} · {c['role']}]\n"
+                           f"{c['snippet']}" for c in chunks)
+    else:
+        text = ("(nothing found within shareable scope — "
+                "see `session-recall share allow`)")
+
+    cand = Candidate(
+        id=secrets.token_hex(4), peer_name=incoming.peer.name,
+        peer_address=incoming.peer.address, question=question, task=task,
+        reply_nonce=incoming.nonce, created_at=time.time(), text=text,
+        chunks=chunks, findings=[asdict(f) for f in scan(text)])
+    cand.version = cand.compute_version()
+    return cand
+
+
+def poll_once(identity: Identity, trust: TrustStore, state: ShareState,
+              transport, searcher: Searcher, share_dir: Path) -> list[Candidate]:
+    """One inbox sweep. Invalid envelopes vanish inside open_incoming (silent
+    drop); valid requests become pending candidates on disk."""
+    out = []
+    for raw in transport.fetch_mail(identity.address):
+        incoming = open_incoming(identity, trust, state, raw)
+        if incoming is None or incoming.kind != "req":
+            continue
+        cand = build_candidate(incoming, searcher, trust.allowed_projects())
+        _write_candidate(share_dir, cand)
+        out.append(cand)
+    return out
+
+
+# -- outbox reading, shared with the approval flow (next PR) -----------------
+def list_pending(share_dir: Path) -> list[Candidate]:
+    d = share_dir / OUTBOX_DIR
+    if not d.is_dir():
+        return []
+    out = []
+    for p in sorted(d.glob("*.json")):
+        cand = Candidate(**json.loads(p.read_text()))
+        if cand.status == "pending":
+            out.append(cand)
+    return out
+
+
+def load_candidate(share_dir: Path, cand_id: str) -> Candidate | None:
+    p = share_dir / OUTBOX_DIR / f"{cand_id}.json"
+    return Candidate(**json.loads(p.read_text())) if p.exists() else None
+
+
+def set_status(share_dir: Path, cand_id: str, status: str) -> Candidate | None:
+    cand = load_candidate(share_dir, cand_id)
+    if cand is None:
+        return None
+    cand.status = status
+    _write_candidate(share_dir, cand)
+    return cand

--- a/tests/test_share_worker.py
+++ b/tests/test_share_worker.py
@@ -1,0 +1,159 @@
+from dataclasses import dataclass
+
+import pytest
+
+from session_recall.share import identity as identity_mod
+from session_recall.share import scanner
+from session_recall.share.envelope import ShareState, make_request
+from session_recall.share.transport import InMemoryTransport
+from session_recall.share.trust import Peer, TrustStore
+from session_recall.share.worker import (
+    build_candidate, list_pending, load_candidate, poll_once, set_status)
+
+
+# -- scanner -----------------------------------------------------------------
+@pytest.mark.parametrize("kind,text", [
+    ("aws-access-key", "creds: AKIAIOSFODNN7EXAMPLE done"),
+    ("openai-key", "export OPENAI_API_KEY=sk-proj-abc123def456ghi789jkl"),
+    ("github-token", "ghp_" + "a1B2" * 9 + " pushed"),
+    ("jwt", "auth eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U"),
+    ("private-key-pem", "-----BEGIN OPENSSH PRIVATE KEY-----"),
+    ("password-assignment", "POSTGRES_PASSWORD=hunter2hunter2"),
+    ("connection-string", "postgres://app:s3cr3tpass@db.internal:5432/prod"),
+])
+def test_scanner_catches(kind, text):
+    kinds = {f.kind for f in scanner.scan(text)}
+    assert kind in kinds
+
+
+def test_scanner_masks_excerpts():
+    findings = scanner.scan("key AKIAIOSFODNN7EXAMPLE")
+    assert findings and "EXAMPLE" not in findings[0].excerpt
+
+
+def test_scanner_quiet_on_prose():
+    text = ("we fixed the CI by pinning mcp below 2.0 because upstream removed "
+            "the fastmcp module; see the decision doc for details")
+    assert scanner.scan(text) == []
+
+
+# -- worker ------------------------------------------------------------------
+@dataclass
+class FakeAnchor:
+    session_id: str
+    uuid: str
+    role: str
+    snippet: str
+    score: float
+    project: str
+    when: int
+    source: str = "claude"
+
+
+def _anchor(project, snippet="how we fixed it", score=0.9):
+    return FakeAnchor("sess-1234567890", "uuid-1", "assistant", snippet,
+                      score, project, 1785000000)
+
+
+@pytest.fixture
+def world(tmp_path):
+    maxim = identity_mod.create(tmp_path / "maxim", "maxim")
+    egor = identity_mod.create(tmp_path / "egor", "egor")
+    trust = TrustStore(tmp_path / "maxim" / "trust.json")
+    b = egor.public_bundle()
+    trust.add(Peer(name=b["name"], address=b["address"],
+                   sign_pk=b["sign_pk"], box_pk=b["box_pk"]))
+    trust.allow_project("session-recall")
+    state = ShareState(tmp_path / "maxim" / "state.json")
+    transport = InMemoryTransport()
+    return maxim, egor, trust, state, transport, tmp_path / "maxim"
+
+
+def _ask(egor, maxim, transport, question="how did you fix CI?", task=""):
+    transport.post_mail(maxim.address,
+                        make_request(egor, maxim.public_bundle(), question, task))
+
+
+def test_poll_builds_candidate_with_provenance(world):
+    maxim, egor, trust, state, transport, sdir = world
+    _ask(egor, maxim, transport, task="debugging our pipeline")
+    searcher = lambda q, k: [_anchor("session-recall"), _anchor("other-project")]
+    cands = poll_once(maxim, trust, state, transport, searcher, sdir)
+    assert len(cands) == 1
+    c = cands[0]
+    assert c.peer_name == "egor"
+    assert c.question == "how did you fix CI?"
+    assert [ch["project"] for ch in c.chunks] == ["session-recall"]  # scope filter
+    assert "session-recall" in c.text and c.version
+    assert c.status == "pending"
+    assert load_candidate(sdir, c.id).question == c.question
+
+
+def test_default_deny_empty_scope(world):
+    maxim, egor, trust, state, transport, sdir = world
+    trust.disallow_project("session-recall")
+    _ask(egor, maxim, transport)
+    called = []
+    searcher = lambda q, k: called.append(q) or [_anchor("session-recall")]
+    cands = poll_once(maxim, trust, state, transport, searcher, sdir)
+    assert cands[0].chunks == []
+    assert "share allow" in cands[0].text
+    assert called == []  # empty allow-list: the index is not even queried
+
+
+def test_secret_in_snippet_flagged(world):
+    maxim, egor, trust, state, transport, sdir = world
+    _ask(egor, maxim, transport)
+    leaky = _anchor("session-recall",
+                    snippet="deploy used AKIAIOSFODNN7EXAMPLE as the key")
+    cands = poll_once(maxim, trust, state, transport, lambda q, k: [leaky], sdir)
+    assert any(f["kind"] == "aws-access-key" for f in cands[0].findings)
+
+
+def test_invalid_envelopes_produce_nothing(world, tmp_path):
+    maxim, egor, trust, state, transport, sdir = world
+    mallory = identity_mod.create(tmp_path / "m", "mallory")
+    transport.post_mail(maxim.address,
+                        make_request(mallory, maxim.public_bundle(), "gimme"))
+    transport.post_mail(maxim.address, b"garbage-bytes")
+    cands = poll_once(maxim, trust, state, transport,
+                      lambda q, k: [_anchor("session-recall")], sdir)
+    assert cands == [] and list_pending(sdir) == []
+
+
+def test_rate_limited_requests_dropped(world):
+    maxim, egor, trust, state, transport, sdir = world
+    for i in range(5):
+        _ask(egor, maxim, transport, question=f"q{i}")
+    cands = poll_once(maxim, trust, state, transport,
+                      lambda q, k: [_anchor("session-recall")], sdir)
+    assert len(cands) == 3  # RATE_PER_MIN; the pump stops at the gate
+
+
+def test_version_binds_to_content(world):
+    maxim, egor, trust, state, transport, sdir = world
+    _ask(egor, maxim, transport)
+    cands = poll_once(maxim, trust, state, transport,
+                      lambda q, k: [_anchor("session-recall")], sdir)
+    c = cands[0]
+    v1 = c.version
+    c.text += " (edited)"
+    assert c.compute_version() != v1  # /ok <old-version> must die after any edit
+
+
+def test_status_lifecycle(world):
+    maxim, egor, trust, state, transport, sdir = world
+    _ask(egor, maxim, transport)
+    c = poll_once(maxim, trust, state, transport,
+                  lambda q, k: [_anchor("session-recall")], sdir)[0]
+    assert [p.id for p in list_pending(sdir)] == [c.id]
+    set_status(sdir, c.id, "approved")
+    assert list_pending(sdir) == []
+    assert load_candidate(sdir, c.id).status == "approved"
+
+
+def test_question_length_capped(world):
+    maxim, egor, trust, state, transport, sdir = world
+    _ask(egor, maxim, transport, question="x" * 10000)
+    cands = poll_once(maxim, trust, state, transport, lambda q, k: [], sdir)
+    assert len(cands[0].question) == 2000


### PR DESCRIPTION
Клетка из спеки: у воркера ровно две возможности — read-only searcher (инжектится) и запись кандидатов в outbox. В модуле нет импорта отправки, канала апрува, shell или произвольной ФС: инъекция, полностью управляющая этим кодом, может лишь сформировать ТЕКСТ, который ляжет перед владельцем.

- **scope default deny**: пустой allow-list даже не дёргает индекс; чанки фильтруются по `share allow`-проектам, у каждого — провенанс (project/session/uuid/role/score)
- **secret-scanner**: тупые регэкспы форматов (AWS/OpenAI/Anthropic/GitHub/GitLab/Slack/JWT/PEM/TG-bot/conn-string/password=) — флаги для владельца, не вердикты; маскированные excerpt-ы
- **version hash** (blake2b от text+chunks) — будущий `/ok <hash>` привязан к точному blob, любая правка меняет версию
- **никаких транскриптов** — обработанные запросы не могут вернуться в индекс как stored-инъекция
- rate-гейт наследуется от `open_incoming` (3/мин срезает насос до кандидатов)
- кандидат собирается детерминированно из recall-якорей; LLM-суммаризация позже перепишет только `text` — конверт кандидата (chunks/flags/version/binding) не изменится

CLI: `share serve --once|--interval N`, `share pending`, `share show <id>`.
17 новых тестов; сюита 199 passed.

Остался PR 4: TG-превью, versioned `/ok`, send-процесс.

🤖 Generated with [Claude Code](https://claude.com/claude-code)