### PR TITLE
feat(share): versioned /ok approval, TG previews, send process (gate v1, PR 4/4)

### DIFF
--- a/src/session_recall/share/approval.py
+++ b/src/session_recall/share/approval.py
@@ -1,0 +1,98 @@
+"""Approval and the send process — the only door out, default deny.
+
+The worker fills the outbox; nothing leaves it without a human decision that
+quotes the candidate's exact version hash. approve() refuses a mismatched
+version, so any edit or regeneration kills previously seen /ok text (the
+TOCTOU rule: an approval blesses a blob, not an intention). dispatch_approved()
+is the single place in the codebase that turns candidates into outgoing
+envelopes; the worker module does not import it and cannot reach it.
+"""
+
+import time
+from pathlib import Path
+
+from .envelope import make_response
+from .identity import Identity
+from .trust import TrustStore
+from .worker import Candidate, list_pending, load_candidate, set_status
+
+PENDING_TTL_S = 24 * 3600
+
+
+def preview(cand: Candidate, redact: bool | None = None) -> str:
+    """The message the owner sees. `redact` hides the answer body — forced on
+    when the scanner flagged anything, because flagged text must not travel
+    through a third-party notification channel (gate §6)."""
+    redact = bool(cand.findings) if redact is None else redact
+    lines = [f"[{cand.id} v{cand.version}] request from {cand.peer_name}",
+             f"question: {cand.question}"]
+    if cand.task:
+        lines.append(f'stated task (sender text, unverified): "{cand.task}"')
+    if cand.findings:
+        kinds = ", ".join(sorted({f["kind"] for f in cand.findings}))
+        lines.append(f"⚠ SECRET FLAGS: {kinds}")
+    if redact:
+        lines.append(f"[answer withheld from this channel — review locally: "
+                     f"session-recall share show {cand.id}]")
+    else:
+        lines.append(f"--- answer v{cand.version} ---\n{cand.text}")
+    lines.append(f"approve: /ok {cand.version}   decline: /no <reason>")
+    return "\n".join(lines)
+
+
+def approve(share_dir: Path, cand_id: str, version: str) -> Candidate | None:
+    """None unless `version` matches the stored candidate exactly."""
+    cand = load_candidate(share_dir, cand_id)
+    if cand is None or cand.status != "pending" or version != cand.version:
+        return None
+    return set_status(share_dir, cand_id, "approved")
+
+
+def reject(share_dir: Path, cand_id: str, reason: str = "") -> Candidate | None:
+    cand = load_candidate(share_dir, cand_id)
+    if cand is None or cand.status != "pending":
+        return None
+    cand.status = "rejected"
+    cand.text = f"(declined) {reason}".strip()  # what, if anything, goes back
+    from .worker import _write_candidate
+    _write_candidate(share_dir, cand)
+    return cand
+
+
+def expire_stale(share_dir: Path, now: float | None = None) -> list[Candidate]:
+    """A three-day-old /ok must not fire a forgotten answer."""
+    now = time.time() if now is None else now
+    out = []
+    for cand in list_pending(share_dir):
+        if now - cand.created_at > PENDING_TTL_S:
+            out.append(set_status(share_dir, cand.id, "expired"))
+    return out
+
+
+def dispatch(identity: Identity, trust: TrustStore, share_dir: Path,
+             transport, statuses: tuple[str, ...] = ("approved", "rejected")) -> list[Candidate]:
+    """Send everything the human has decided on. Approved candidates carry the
+    answer; rejected ones carry the decline note so the peer is not left
+    hanging. Peers revoked since the decision drop silently — fail closed."""
+    from .worker import OUTBOX_DIR
+    import json
+    sent = []
+    d = share_dir / OUTBOX_DIR
+    if not d.is_dir():
+        return sent
+    for p in sorted(d.glob("*.json")):
+        cand = Candidate(**json.loads(p.read_text()))
+        if cand.status not in statuses:
+            continue
+        peer = trust.get_by_address(cand.peer_address)
+        if peer is None:
+            set_status(share_dir, cand.id, "dropped-revoked")
+            continue
+        transport.post_mail(peer.address,
+                            make_response(identity, peer, cand.text,
+                                          in_reply_to=cand.reply_nonce))
+        # keep the audit trail honest: a delivered decline is not an answer
+        set_status(share_dir, cand.id,
+                   "sent" if cand.status == "approved" else "declined-sent")
+        sent.append(cand)
+    return sent

--- a/src/session_recall/share/cli.py
+++ b/src/session_recall/share/cli.py
@@ -47,6 +47,18 @@ def add_parser(sub) -> None:
     ssub.add_parser("pending", help="list candidates waiting for approval")
     shp2 = ssub.add_parser("show", help="print one candidate in full")
     shp2.add_argument("id")
+    tgp = ssub.add_parser("tg-setup", help="bind the Telegram approval bot")
+    tgp.add_argument("--token", default=None,
+                     help="bot token (default: $SESSION_RECALL_TG_TOKEN)")
+    nfp = ssub.add_parser("notify", help="run the full loop: worker + TG approval + send")
+    nfp.add_argument("--once", action="store_true")
+    nfp.add_argument("--interval", type=int, default=5)
+    okp = ssub.add_parser("approve", help="approve a candidate locally (no TG)")
+    okp.add_argument("id")
+    okp.add_argument("version")
+    dcp = ssub.add_parser("decline", help="decline a candidate locally (no TG)")
+    dcp.add_argument("id")
+    dcp.add_argument("reason", nargs="*")
 
 
 def _sas_block(res: pairing.PairingResult) -> str:
@@ -161,6 +173,93 @@ def run(args: argparse.Namespace) -> int:
             for f in cand.findings:
                 print(f"  - {f['kind']}: {f['excerpt']}")
         print(f"\n--- candidate answer (v{cand.version}) ---\n{cand.text}")
+        return 0
+
+    if cmd == "tg-setup":
+        from .telegram import TgApi, TgConfig, save_config
+        token = args.token or os.environ.get("SESSION_RECALL_TG_TOKEN")
+        if not token:
+            print("need a bot token: --token or SESSION_RECALL_TG_TOKEN "
+                  "(create one via @BotFather)")
+            return 1
+        api = TgApi(token)
+        print("token saved. Now open your bot in Telegram and send it /start "
+              "(waiting up to 2 min)…")
+        cfg = TgConfig(token=token, chat_id=None)
+        save_config(sdir, cfg)
+        import time as _time
+        deadline = _time.time() + 120
+        offset = 0
+        while _time.time() < deadline:
+            for u in api.get_updates(offset, timeout=20):
+                offset = max(offset, u.get("update_id", 0) + 1)
+                msg = u.get("message") or {}
+                if (msg.get("text") or "").strip() == "/start":
+                    cfg.chat_id = msg["chat"]["id"]
+                    cfg.offset = offset
+                    save_config(sdir, cfg)
+                    api.send_message(cfg.chat_id,
+                                     "bound — approvals will arrive here")
+                    print(f"bound to chat {cfg.chat_id}")
+                    return 0
+        print("no /start received — run tg-setup again")
+        return 1
+
+    if cmd in ("approve", "decline"):
+        from . import approval
+        transport = from_env(os.environ, identity=ident)
+        if cmd == "approve":
+            cand = approval.approve(sdir, args.id, args.version)
+            if cand is None:
+                print("not approved: wrong version or not pending "
+                      f"(see: session-recall share show {args.id})")
+                return 1
+        else:
+            cand = approval.reject(sdir, args.id, " ".join(args.reason))
+            if cand is None:
+                print(f"nothing pending under {args.id!r}")
+                return 1
+        if transport is None:
+            print("decision recorded; no transport configured so nothing sent yet "
+                  f"— {_TRANSPORT_HINT}")
+            return 0
+        sent = approval.dispatch(ident, trust, sdir, transport)
+        for c in sent:
+            print(f"{'sent' if c.status != 'rejected' else 'decline sent'}: "
+                  f"{c.id} → {c.peer_name}")
+        return 0
+
+    if cmd == "notify":
+        from .notify import NotifyLoop
+        from .telegram import TgApi, load_config
+        from .envelope import ShareState
+        cfg = load_config(sdir)
+        if cfg is None or cfg.chat_id is None:
+            print("telegram not bound — run: session-recall share tg-setup")
+            return 1
+        transport = from_env(os.environ, identity=ident)
+        if transport is None:
+            print(_TRANSPORT_HINT)
+            return 1
+        from .. import config as _config
+        from ..embed import make_embedder
+        from ..rerank import make_reranker
+        from ..retrieve import Recall
+        from ..store import Store
+        store = Store(_config.DB_PATH)
+        recall = Recall(store, make_embedder(), make_reranker())
+        loop = NotifyLoop(TgApi(cfg.token), ident, trust,
+                          ShareState(sdir / "state.json"), transport,
+                          lambda q, k: recall.recall_search(q, k=k), sdir, cfg)
+        try:
+            if args.once:
+                stats = loop.tick()
+                print(stats)
+                return 0
+            print("approval loop running (Ctrl-C to stop)")
+            loop.run_forever(args.interval)
+        finally:
+            store.close()
         return 0
 
     if cmd == "trust":

--- a/src/session_recall/share/notify.py
+++ b/src/session_recall/share/notify.py
@@ -1,0 +1,107 @@
+"""The owner's approval loop: previews out, /ok — /no back, then dispatch.
+
+Channel-agnostic: `api` is anything with send_message/get_updates (TgApi in
+production, a fake in tests). Binding rules:
+
+- only messages from the single bound owner chat are read at all;
+- /ok must be a REPLY to a preview and must quote the version hash from it —
+  the reply names the candidate, the quoted hash names the exact blob, so an
+  ambiguous or automatic approval has nothing to grab;
+- the candidate reference is parsed from the quoted preview text, not from
+  memory, so a daemon restart loses nothing;
+- every decision path funnels into approval.py — this module owns no crypto
+  and no envelope construction.
+"""
+
+import re
+import time
+from pathlib import Path
+
+from . import approval
+from .envelope import ShareState
+from .identity import Identity
+from .telegram import TgConfig, save_config
+from .trust import TrustStore
+from .worker import Searcher, poll_once
+
+_REF_RE = re.compile(r"^\[([0-9a-f]{8}) v([0-9a-f]{8})\]")
+_USAGE = "usage: reply to a preview with `/ok <version>` or `/no <reason>`"
+
+
+def _cand_ref(message: dict) -> tuple[str, str] | None:
+    quoted = (message.get("reply_to_message") or {}).get("text", "")
+    m = _REF_RE.match(quoted)
+    return (m.group(1), m.group(2)) if m else None
+
+
+class NotifyLoop:
+    def __init__(self, api, identity: Identity, trust: TrustStore,
+                 state: ShareState, transport, searcher: Searcher,
+                 share_dir: Path, cfg: TgConfig):
+        self.api, self.identity, self.trust = api, identity, trust
+        self.state, self.transport, self.searcher = state, transport, searcher
+        self.share_dir, self.cfg = share_dir, cfg
+
+    def _say(self, text: str, reply_to: int | None = None) -> None:
+        self.api.send_message(self.cfg.chat_id, text, reply_to=reply_to)
+
+    def _handle(self, message: dict) -> None:
+        text = (message.get("text") or "").strip()
+        mid = message.get("message_id")
+        if not (text.startswith("/ok") or text.startswith("/no")):
+            return
+        ref = _cand_ref(message)
+        if ref is None:
+            return self._say(_USAGE, reply_to=mid)
+        cand_id, _preview_version = ref  # the reply names the candidate…
+
+        if text.startswith("/ok"):
+            parts = text.split()
+            if len(parts) != 2:
+                return self._say(_USAGE, reply_to=mid)
+            # …while the TYPED hash is what gets compared to the stored one:
+            # retyping it from the preview is the deliberate human step, and a
+            # stale preview after an edit simply cannot supply the right hash.
+            cand = approval.approve(self.share_dir, cand_id, parts[1])
+            if cand is None:
+                return self._say(
+                    f"not approved: version mismatch or not pending "
+                    f"(review: session-recall share show {cand_id})", reply_to=mid)
+            self._say(f"approved {cand_id} v{cand.version} — sending", reply_to=mid)
+        else:
+            reason = text[3:].strip()
+            cand = approval.reject(self.share_dir, cand_id, reason)
+            if cand is None:
+                return self._say(f"nothing pending under {cand_id}", reply_to=mid)
+            self._say(f"declined {cand_id}", reply_to=mid)
+
+    def tick(self, now: float | None = None) -> dict:
+        stats = {"previews": 0, "handled": 0, "sent": 0, "expired": 0}
+
+        for cand in poll_once(self.identity, self.trust, self.state,
+                              self.transport, self.searcher, self.share_dir):
+            self._say(approval.preview(cand))
+            stats["previews"] += 1
+
+        stats["expired"] = len(approval.expire_stale(self.share_dir, now))
+
+        for update in self.api.get_updates(self.cfg.offset):
+            self.cfg.offset = max(self.cfg.offset, update.get("update_id", 0) + 1)
+            message = update.get("message") or {}
+            if (message.get("chat") or {}).get("id") != self.cfg.chat_id:
+                continue          # anyone else talking to the bot is noise
+            self._handle(message)
+            stats["handled"] += 1
+        save_config(self.share_dir, self.cfg)
+
+        for cand in approval.dispatch(self.identity, self.trust,
+                                      self.share_dir, self.transport):
+            if cand.status != "rejected":
+                self._say(f"sent to {cand.peer_name}: {cand.id} v{cand.version}")
+            stats["sent"] += 1
+        return stats
+
+    def run_forever(self, interval_s: float = 5.0) -> None:
+        while True:
+            self.tick()
+            time.sleep(interval_s)

--- a/src/session_recall/share/telegram.py
+++ b/src/session_recall/share/telegram.py
@@ -1,0 +1,71 @@
+"""Telegram Bot API over stdlib urllib — sendMessage and getUpdates are two
+endpoints and do not justify a dependency.
+
+Privacy posture (gate §6): everything sent through here transits Telegram's
+servers, so flagged answers are redacted upstream (approval.preview) and all
+messages go as plain text — parse_mode is never set, links are never rendered,
+sender-controlled strings cannot become formatting or buttons. The bot config
+binds to exactly one owner chat; updates from any other chat are discarded
+before parsing.
+"""
+
+import json
+import os
+import stat
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+TG_FILE = "tg.json"
+_TIMEOUT_S = 35   # long-poll friendly
+
+
+@dataclass
+class TgConfig:
+    token: str
+    chat_id: int | None
+    offset: int = 0
+
+
+def load_config(share_dir: Path) -> TgConfig | None:
+    p = share_dir / TG_FILE
+    if not p.exists():
+        return None
+    raw = json.loads(p.read_text())
+    return TgConfig(token=raw["token"], chat_id=raw.get("chat_id"),
+                    offset=raw.get("offset", 0))
+
+
+def save_config(share_dir: Path, cfg: TgConfig) -> None:
+    share_dir.mkdir(parents=True, exist_ok=True)
+    p = share_dir / TG_FILE
+    fd = os.open(p, os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+                 stat.S_IRUSR | stat.S_IWUSR)
+    with os.fdopen(fd, "w") as f:
+        json.dump({"token": cfg.token, "chat_id": cfg.chat_id,
+                   "offset": cfg.offset}, f)
+
+
+class TgApi:
+    def __init__(self, token: str):
+        self.base = f"https://api.telegram.org/bot{token}"
+
+    def _call(self, method: str, **params) -> dict:
+        data = urllib.parse.urlencode(
+            {k: v for k, v in params.items() if v is not None}).encode()
+        with urllib.request.urlopen(f"{self.base}/{method}", data=data,
+                                    timeout=_TIMEOUT_S) as resp:
+            payload = json.loads(resp.read())
+        return payload.get("result", {})
+
+    def send_message(self, chat_id: int, text: str,
+                     reply_to: int | None = None) -> int | None:
+        # 4096 is Telegram's hard cap; truncate rather than fail the preview
+        result = self._call("sendMessage", chat_id=chat_id, text=text[:4096],
+                            reply_to_message_id=reply_to)
+        return result.get("message_id") if isinstance(result, dict) else None
+
+    def get_updates(self, offset: int, timeout: int = 25) -> list[dict]:
+        result = self._call("getUpdates", offset=offset, timeout=timeout)
+        return result if isinstance(result, list) else []

--- a/tests/test_share_approval.py
+++ b/tests/test_share_approval.py
@@ -1,0 +1,246 @@
+from dataclasses import dataclass
+
+import pytest
+
+from session_recall.share import approval
+from session_recall.share import identity as identity_mod
+from session_recall.share.envelope import ShareState, make_request, open_incoming
+from session_recall.share.notify import NotifyLoop
+from session_recall.share.telegram import TgConfig
+from session_recall.share.transport import InMemoryTransport
+from session_recall.share.trust import Peer, TrustStore
+from session_recall.share.worker import load_candidate, poll_once
+
+OWNER_CHAT = 111
+
+
+@dataclass
+class FakeAnchor:
+    session_id: str = "sess-1234567890"
+    uuid: str = "u1"
+    role: str = "assistant"
+    snippet: str = "we pinned mcp below 2 and CI went green"
+    score: float = 0.9
+    project: str = "session-recall"
+    when: int = 1785000000
+    source: str = "claude"
+
+
+class FakeApi:
+    def __init__(self):
+        self.outbox: list[tuple[int, str]] = []
+        self.updates: list[dict] = []
+        self._mid = 0
+
+    def send_message(self, chat_id, text, reply_to=None):
+        self._mid += 1
+        self.outbox.append((chat_id, text))
+        return self._mid
+
+    def get_updates(self, offset, timeout=25):
+        pending = [u for u in self.updates if u["update_id"] >= offset]
+        return pending
+
+    # test helpers
+    def owner_says(self, text, quoted_text, update_id, chat=OWNER_CHAT):
+        self.updates.append({
+            "update_id": update_id,
+            "message": {"message_id": 1000 + update_id, "chat": {"id": chat},
+                        "text": text,
+                        "reply_to_message": {"text": quoted_text}}})
+
+
+@pytest.fixture
+def world(tmp_path):
+    maxim = identity_mod.create(tmp_path / "maxim", "maxim")
+    egor = identity_mod.create(tmp_path / "egor", "egor")
+    trust = TrustStore(tmp_path / "maxim" / "trust.json")
+    b = egor.public_bundle()
+    trust.add(Peer(name=b["name"], address=b["address"],
+                   sign_pk=b["sign_pk"], box_pk=b["box_pk"]))
+    trust.allow_project("session-recall")
+    egor_trust = TrustStore(tmp_path / "egor" / "trust.json")
+    mb = maxim.public_bundle()
+    egor_trust.add(Peer(name=mb["name"], address=mb["address"],
+                        sign_pk=mb["sign_pk"], box_pk=mb["box_pk"]))
+    return {
+        "maxim": maxim, "egor": egor, "trust": trust, "egor_trust": egor_trust,
+        "state": ShareState(tmp_path / "maxim" / "state.json"),
+        "transport": InMemoryTransport(), "sdir": tmp_path / "maxim",
+        "edir": tmp_path / "egor",
+    }
+
+
+def _incoming_candidate(w, question="how did you fix CI?"):
+    w["transport"].post_mail(
+        w["maxim"].address,
+        make_request(w["egor"], w["maxim"].public_bundle(), question))
+    return poll_once(w["maxim"], w["trust"], w["state"], w["transport"],
+                     lambda q, k: [FakeAnchor()], w["sdir"])[0]
+
+
+# -- approval core -----------------------------------------------------------
+def test_approve_needs_exact_version(world):
+    c = _incoming_candidate(world)
+    assert approval.approve(world["sdir"], c.id, "00000000") is None
+    assert load_candidate(world["sdir"], c.id).status == "pending"
+    assert approval.approve(world["sdir"], c.id, c.version).status == "approved"
+
+
+def test_approve_only_from_pending(world):
+    c = _incoming_candidate(world)
+    approval.approve(world["sdir"], c.id, c.version)
+    assert approval.approve(world["sdir"], c.id, c.version) is None  # already approved
+
+
+def test_preview_redacts_flagged_answers(world):
+    c = _incoming_candidate(world)
+    c.findings = [{"kind": "aws-access-key", "excerpt": "AKIAIOSF…"}]
+    text = approval.preview(c)
+    assert "withheld" in text and c.text not in text
+    assert "SECRET FLAGS" in text
+    clean = approval.preview(_incoming_candidate(world, question="q2"))
+    assert "withheld" not in clean
+
+
+def test_expire_stale(world):
+    c = _incoming_candidate(world)
+    later = c.created_at + approval.PENDING_TTL_S + 1
+    expired = approval.expire_stale(world["sdir"], now=later)
+    assert [e.id for e in expired] == [c.id]
+    assert approval.approve(world["sdir"], c.id, c.version) is None
+
+
+def test_dispatch_sends_only_decided(world):
+    c1 = _incoming_candidate(world, "q1")
+    _c2 = _incoming_candidate(world, "q2")            # stays pending
+    approval.approve(world["sdir"], c1.id, c1.version)
+    sent = approval.dispatch(world["maxim"], world["trust"], world["sdir"],
+                             world["transport"])
+    assert [s.id for s in sent] == [c1.id]
+    assert load_candidate(world["sdir"], c1.id).status == "sent"
+
+    # egor receives a verifiable response bound to his original request
+    inbox = world["transport"].fetch_mail(world["egor"].address)
+    assert len(inbox) == 1
+    got = open_incoming(world["egor"], world["egor_trust"],
+                        ShareState(world["edir"] / "state.json"), inbox[0])
+    assert got.kind == "resp"
+    assert got.in_reply_to == c1.reply_nonce
+    assert "mcp below 2" in got.body["text"]
+
+
+def test_dispatch_drops_revoked_peer(world):
+    c = _incoming_candidate(world)
+    approval.approve(world["sdir"], c.id, c.version)
+    world["trust"].revoke("egor")
+    sent = approval.dispatch(world["maxim"], world["trust"], world["sdir"],
+                             world["transport"])
+    assert sent == []
+    assert load_candidate(world["sdir"], c.id).status == "dropped-revoked"
+    assert world["transport"].fetch_mail(world["egor"].address) == []
+
+
+def test_declined_send_is_labelled(world):
+    c = _incoming_candidate(world)
+    approval.reject(world["sdir"], c.id, "not sharing that")
+    approval.dispatch(world["maxim"], world["trust"], world["sdir"],
+                      world["transport"])
+    assert load_candidate(world["sdir"], c.id).status == "declined-sent"
+    inbox = world["transport"].fetch_mail(world["egor"].address)
+    got = open_incoming(world["egor"], world["egor_trust"],
+                        ShareState(world["edir"] / "state.json"), inbox[0])
+    assert got.body["text"].startswith("(declined)")
+
+
+# -- notify loop -------------------------------------------------------------
+def _loop(w, api):
+    return NotifyLoop(api, w["maxim"], w["trust"], w["state"], w["transport"],
+                      lambda q, k: [FakeAnchor()], w["sdir"],
+                      TgConfig(token="t", chat_id=OWNER_CHAT))
+
+
+def test_loop_preview_ok_send(world):
+    api = FakeApi()
+    loop = _loop(world, api)
+    world["transport"].post_mail(
+        world["maxim"].address,
+        make_request(world["egor"], world["maxim"].public_bundle(), "how?"))
+    loop.tick()
+    assert len(api.outbox) == 1
+    preview_text = api.outbox[0][1]
+    cand_id, version = preview_text[1:9], preview_text[11:19]
+
+    api.owner_says(f"/ok {version}", preview_text, update_id=1)
+    loop.tick()
+    texts = [t for _, t in api.outbox]
+    assert any("approved" in t for t in texts)
+    assert any(t.startswith("sent to egor") for t in texts)
+    inbox = world["transport"].fetch_mail(world["egor"].address)
+    assert len(inbox) == 1
+
+
+def test_loop_rejects_wrong_version_and_bare_ok(world):
+    api = FakeApi()
+    loop = _loop(world, api)
+    world["transport"].post_mail(
+        world["maxim"].address,
+        make_request(world["egor"], world["maxim"].public_bundle(), "how?"))
+    loop.tick()
+    preview_text = api.outbox[0][1]
+
+    api.owner_says("/ok 00000000", preview_text, update_id=1)
+    api.owner_says("/ok", preview_text, update_id=2)
+    loop.tick()
+    texts = [t for _, t in api.outbox]
+    assert any("not approved" in t for t in texts)
+    assert any("usage:" in t for t in texts)
+    assert world["transport"].fetch_mail(world["egor"].address) == []
+
+
+def test_loop_ignores_strangers(world):
+    api = FakeApi()
+    loop = _loop(world, api)
+    world["transport"].post_mail(
+        world["maxim"].address,
+        make_request(world["egor"], world["maxim"].public_bundle(), "how?"))
+    loop.tick()
+    preview_text = api.outbox[0][1]
+    _, version = preview_text[1:9], preview_text[11:19]
+
+    api.owner_says(f"/ok {version}", preview_text, update_id=1, chat=999)
+    loop.tick()
+    assert world["transport"].fetch_mail(world["egor"].address) == []
+    assert not any("approved" in t for _, t in api.outbox)
+
+
+def test_loop_no_declines_with_reason(world):
+    api = FakeApi()
+    loop = _loop(world, api)
+    world["transport"].post_mail(
+        world["maxim"].address,
+        make_request(world["egor"], world["maxim"].public_bundle(), "how?"))
+    loop.tick()
+    preview_text = api.outbox[0][1]
+
+    api.owner_says("/no ask me tomorrow", preview_text, update_id=1)
+    loop.tick()
+    inbox = world["transport"].fetch_mail(world["egor"].address)
+    got = open_incoming(world["egor"], world["egor_trust"],
+                        ShareState(world["edir"] / "state.json"), inbox[0])
+    assert got.body["text"] == "(declined) ask me tomorrow"
+
+
+def test_loop_offset_advances_no_replay_of_commands(world):
+    api = FakeApi()
+    loop = _loop(world, api)
+    world["transport"].post_mail(
+        world["maxim"].address,
+        make_request(world["egor"], world["maxim"].public_bundle(), "how?"))
+    loop.tick()
+    preview_text = api.outbox[0][1]
+    _, version = preview_text[1:9], preview_text[11:19]
+    api.owner_says(f"/ok {version}", preview_text, update_id=7)
+    loop.tick()
+    handled_twice = loop.tick()   # same update must not be seen again
+    assert handled_twice["handled"] == 0


### PR DESCRIPTION
Замыкает контур спеки — выходной рубеж:

- **versioned апрув**: `/ok` обязан быть reply на превью (называет кандидата) И содержать перепечатанный хеш версии (называет точный blob). Правка/регенерация меняет хеш — устаревшее превью физически не может дать правильный `/ok` (анти-TOCTOU из спеки)
- **redaction**: кандидаты с secret-флагами в TG не едут — превью только с метаданными и командой `share show <id>` для локального просмотра
- **периметр канала**: читается только привязанный owner-чат; parse_mode не ставится никогда — текст отправителя не может стать разметкой/ссылками
- **таймаут**: pending протухает через 24ч, `/ok` по забытому не выстрелит
- **send-процесс**: `dispatch()` — единственная дверь наружу во всём пакете; шлёт одобренные ответы и явные отказы (`/no причина` → «(declined) …» Егору), оба — подписанные E2E-конверты с `in_reply_to` нонсом исходного запроса; отозванный после решения peer → fail-closed drop
- Bot API на stdlib urllib (sendMessage + getUpdates, зависимостей ноль)
- CLI: `share tg-setup`, `share notify [--once]`, локальные `share approve/decline` без TG

12 новых тестов (ядро апрува + NotifyLoop с фейковым API: happy-path, неверная версия, чужой чат, decline, отсутствие replay команд). Сюита: 211 passed.

Гейт v1 собран целиком: PR #14 вход → PR #15 relay → PR #16 клетка → этот PR выход.

🤖 Generated with [Claude Code](https://claude.com/claude-code)