### PR TITLE
fix(share): relay binds localhost by default

### DIFF
--- a/src/session_recall/share/cli.py
+++ b/src/session_recall/share/cli.py
@@ -39,6 +39,8 @@ def add_parser(sub) -> None:
     ap.add_argument("--remove", action="store_true")
     rlp = ssub.add_parser("relay", help="run the relay server (blind blob store)")
     rlp.add_argument("--port", type=int, default=8787)
+    rlp.add_argument("--host", default="127.0.0.1",
+                     help="bind address (default: localhost, for use behind TLS)")
     rlp.add_argument("--data", default=None,
                      help="storage dir (default: <data-dir>/share-relay)")
     svp = ssub.add_parser("serve", help="poll inbox, build candidate answers")
@@ -75,7 +77,8 @@ def run(args: argparse.Namespace) -> int:
     if cmd == "relay":
         from pathlib import Path
         from .relay import serve
-        serve(args.port, Path(args.data) if args.data else config.DATA_DIR / "share-relay")
+        serve(args.port, Path(args.data) if args.data else config.DATA_DIR / "share-relay",
+              host=args.host)
         return 0
 
     if cmd == "init":

--- a/src/session_recall/share/relay.py
+++ b/src/session_recall/share/relay.py
@@ -185,7 +185,10 @@ def make_handler(store: RelayStore):
     return Handler
 
 
-def serve(port: int, data_dir: Path) -> None:
-    server = ThreadingHTTPServer(("0.0.0.0", port), make_handler(RelayStore(data_dir)))
-    print(f"relay listening on :{port}, data in {data_dir}", flush=True)
+def serve(port: int, data_dir: Path, host: str = "127.0.0.1") -> None:
+    """Localhost by default: the relay speaks plain HTTP, so a public bind
+    would put addresses and blobs on the wire unencrypted. Production runs it
+    behind a TLS terminator; pass host explicitly to override."""
+    server = ThreadingHTTPServer((host, port), make_handler(RelayStore(data_dir)))
+    print(f"relay listening on {host}:{port}, data in {data_dir}", flush=True)
     server.serve_forever()


### PR DESCRIPTION
Relay говорит по plain HTTP, а слушал `0.0.0.0` — адреса ящиков и блобы уезжали бы в сеть открытым текстом. Дефолт `127.0.0.1`, продакшн — за TLS-терминатором (nginx); `--host` для случаев, когда TLS терминируется иначе.

Замечено при деплое на Netcup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)