### PR TITLE
feat(share): zero-config onboarding — public relay as default transport

### DIFF
--- a/src/session_recall/share/cli.py
+++ b/src/session_recall/share/cli.py
@@ -17,8 +17,9 @@ from .transport import from_env
 from .trust import Peer, TrustStore
 
 _TRANSPORT_HINT = (
-    "no transport configured: set SESSION_RECALL_RELAY_URL (relay) or "
-    "SESSION_RECALL_SHARE_TRANSPORT_DIR (shared folder)")
+    "transport disabled (SESSION_RECALL_RELAY_URL=none) — unset it to use the "
+    "default relay, set it to your own relay, or set "
+    "SESSION_RECALL_SHARE_TRANSPORT_DIR for a shared folder")
 
 
 def add_parser(sub) -> None:

--- a/src/session_recall/share/transport.py
+++ b/src/session_recall/share/transport.py
@@ -119,12 +119,29 @@ class HttpRelayTransport:
         return [base64.b64decode(i) for i in items]
 
 
+# The public relay every fresh install talks to, so onboarding is
+# `share init` → `share invite` with zero configuration. Baking it in is safe
+# because the relay is blind: everything it carries is sealed and signed
+# client-side, so WHICH relay both sides use is coordination, not trust — and a
+# built-in default is the one value two strangers already agree on.
+#
+# Deliberately NOT taken from the pairing bundle: a bundle is peer-supplied
+# data, and a relay URL inside it would let a malicious bundle point this
+# client at an attacker's server. Changing relays is manual by design.
+DEFAULT_RELAY_URL = "https://relay.terra-sandbox.ru"
+
+
 def from_env(env: dict, identity=None) -> Transport | None:
-    """Relay URL wins; a shared directory is the zero-infra fallback."""
-    url = env.get("SESSION_RECALL_RELAY_URL")
-    if url:
+    """Explicit relay URL wins; a shared directory is the zero-infra fallback;
+    otherwise the public relay. `SESSION_RECALL_RELAY_URL=none` (or `off`)
+    disables the relay — with no directory configured that means no transport
+    at all, for installs that must never speak to the network."""
+    url = (env.get("SESSION_RECALL_RELAY_URL") or "").strip()
+    if url and url.lower() not in ("none", "off"):
         return HttpRelayTransport(url, identity=identity)
     root = env.get("SESSION_RECALL_SHARE_TRANSPORT_DIR")
     if root:
         return FileTransport(Path(root))
-    return None
+    if url:                      # explicit none/off, nothing else configured
+        return None
+    return HttpRelayTransport(DEFAULT_RELAY_URL, identity=identity)

--- a/tests/test_share_cli.py
+++ b/tests/test_share_cli.py
@@ -103,9 +103,12 @@ def test_commands_without_identity_point_to_init(homes, capsys):
     assert "share init" in capsys.readouterr().out
 
 
-def test_no_transport_hint(homes, capsys, monkeypatch):
+def test_transport_opt_out_hint(homes, capsys, monkeypatch):
+    """With a built-in default relay the only path to "no transport" is the
+    explicit opt-out — and it must say how to get back."""
     monkeypatch.delenv("SESSION_RECALL_SHARE_TRANSPORT_DIR", raising=False)
+    monkeypatch.setenv("SESSION_RECALL_RELAY_URL", "none")
     homes("maxim")
     _run(["share", "init", "maxim"])
     assert _run(["share", "invite"]) == 1
-    assert "no transport configured" in capsys.readouterr().out
+    assert "transport disabled" in capsys.readouterr().out

--- a/tests/test_share_transport.py
+++ b/tests/test_share_transport.py
@@ -1,0 +1,31 @@
+"""Transport selection: explicit env wins, the public relay is the default
+(zero-config onboarding), and `none` opts out of the network entirely."""
+
+from session_recall.share.transport import (
+    DEFAULT_RELAY_URL, FileTransport, HttpRelayTransport, from_env)
+
+
+def test_default_is_the_public_relay():
+    t = from_env({})
+    assert isinstance(t, HttpRelayTransport)
+    assert t.base == DEFAULT_RELAY_URL.rstrip("/")
+
+
+def test_explicit_url_wins(tmp_path):
+    t = from_env({"SESSION_RECALL_RELAY_URL": "https://my.example",
+                  "SESSION_RECALL_SHARE_TRANSPORT_DIR": str(tmp_path)})
+    assert isinstance(t, HttpRelayTransport) and t.base == "https://my.example"
+
+
+def test_shared_dir_beats_the_default(tmp_path):
+    assert isinstance(from_env(
+        {"SESSION_RECALL_SHARE_TRANSPORT_DIR": str(tmp_path)}), FileTransport)
+
+
+def test_none_disables_the_relay(tmp_path):
+    for v in ("none", "off", "NONE", " none "):
+        assert from_env({"SESSION_RECALL_RELAY_URL": v}) is None
+    # …but an explicit shared folder still works alongside the opt-out
+    t = from_env({"SESSION_RECALL_RELAY_URL": "none",
+                  "SESSION_RECALL_SHARE_TRANSPORT_DIR": str(tmp_path)})
+    assert isinstance(t, FileTransport)


### PR DESCRIPTION
Onboarding drops to `share init` → `share invite`: with nothing configured the client uses `https://relay.terra-sandbox.ru`. Safe to bake in because the relay is blind — everything it carries is sealed and signed client-side, so the relay choice is coordination, not trust, and a built-in default is the one value two strangers already agree on.

Precedence: `SESSION_RECALL_RELAY_URL` (own relay) → `SESSION_RECALL_SHARE_TRANSPORT_DIR` (shared folder) → default relay. `SESSION_RECALL_RELAY_URL=none|off` opts out of the network entirely (with a folder configured it disables only the relay).

Rejected: carrying the relay URL in the pairing bundle — peer-supplied data must not choose where this client sends.

Tests: 274 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)