### PR TITLE
feat(metadocs): living project memory distilled from sessions into a git repo

### DIFF
--- a/src/session_recall/metadocs/collect.py
+++ b/src/session_recall/metadocs/collect.py
@@ -18,7 +18,9 @@ from .config import PROJECT_ALL, PROJECT_GIT, Watermarks
 # oldest-first until the budget is hit; the rest simply waits for the next run
 # (watermarks only advance over what was actually taken), so a giant day is
 # processed across several runs instead of overflowing one model call.
-BUDGET_CHARS = 60_000
+# 40K measured as the practical ceiling: distilling one batch into several
+# complete documents already takes minutes; bigger batches hit the timeout.
+BUDGET_CHARS = 40_000
 MAX_TURN_CHARS = 4_000     # one pasted log must not eat the whole budget
 
 

--- a/src/session_recall/metadocs/distill.py
+++ b/src/session_recall/metadocs/distill.py
@@ -17,7 +17,11 @@ import subprocess
 import tempfile
 from typing import Callable
 
-CLI_TIMEOUT_S = 300
+# Generous on purpose: a backfill batch asks the model to write several
+# complete documents from ~40K chars of dialogue, which measured well past
+# five minutes. This is an unattended nightly job — patience is free, and a
+# timeout only means the batch retries tomorrow.
+CLI_TIMEOUT_S = 900
 
 # distiller(project, dialogue_text, current_docs) -> {filename: new_content} | None
 Distiller = Callable[[str, str, dict], dict | None]


### PR DESCRIPTION
A daily launchd job reads the new dialogue out of the index (user messages
and final answers only — the surface layer the indexer already stores) and
keeps four documents current in a repo of the owner's choice: per-project
bugs.md (how each bug was recognized, diagnosed, fixed, proven fixed),
actions.md (procedures an agent can follow alone), decisions.md (what was
decided, why, what was rejected), and a global USER.md — a map of where the
owner's information lives and how to FIND it, retrieval instructions only.

Design decisions, recorded in docs/decisions/2026-07-31-metadocs-living-
project-memory.md: a git repo instead of a database (diff is review, revert
is undo, blame is audit, pushing the repo is team sharing); per-session
watermarks that advance only after a safe write (a crash re-processes,
never skips); a strict output protocol (complete files between markers, a
filename whitelist, garbage discarded whole); the share secret scanner as a
hard gate before any byte reaches the repo; the distiller caged exactly like
the share composer (claude -p, no tools, argv prompt, empty cwd, dialogue
pinned as data-not-instructions).

Selector: --projects git (default) tracks every project whose cwd is still
a git checkout; all, or explicit names. launchd over cron so a missed run
fires once on wake; the enabling user's PATH is frozen into the plist so
the distiller finds claude.

29 new tests; suite 293 passed.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
