### PR TITLE
feat(metadocs): make update-before-add explicit in the distiller prompt

### DIFF
--- a/src/session_recall/metadocs/distill.py
+++ b/src/session_recall/metadocs/distill.py
@@ -54,9 +54,11 @@ storage locations, lookup commands, naming schemes. Retrieval instructions \
 ONLY — never copy the stored values themselves into the map.
 
 Rules:
-- Update existing entries instead of duplicating them; merge when the new \
-dialogue continues an old story. Keep entries that the new dialogue does not \
-touch.
+- Before adding ANYTHING, search the current documents for an entry about the \
+same bug, action, decision, or storage location — and update or extend that \
+entry instead of adding a twin. A new entry is for a genuinely new story only; \
+merge when the new dialogue continues an old one. Keep entries the new \
+dialogue does not touch.
 - Every entry ends with a `sources:` line listing session ids it came from. \
 Cite artifacts that exist outside this machine (PR numbers, commits, paths) \
 so an entry can be checked without the transcripts.

--- a/tests/test_metadocs.py
+++ b/tests/test_metadocs.py
@@ -121,6 +121,13 @@ def test_prompt_marks_dialogue_as_data():
            "never copy the stored values themselves" in distill._SYSTEM
 
 
+def test_prompt_demands_update_before_add():
+    """Maxim's rule: актуализировать — look for an existing entry first,
+    adding a twin is the failure mode."""
+    assert "Before adding ANYTHING" in distill._SYSTEM
+    assert "instead of adding a twin" in distill._SYSTEM
+
+
 def test_cli_distiller_runs_in_empty_cwd_no_tools():
     seen = {}
 


### PR DESCRIPTION
The model always receives the complete current documents, so it CAN check
what exists; now the prompt demands it: before adding anything, search for
an existing entry about the same story and extend it — a twin entry is the
failure mode. Requested by Maxim for the all-projects rollout.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
