### PR TITLE
fix(metadocs): bare-UUID "projects" are index junk — all/git selectors skip them

### DIFF
--- a/src/session_recall/metadocs/collect.py
+++ b/src/session_recall/metadocs/collect.py
@@ -16,6 +16,7 @@ chunks table), so distilling needs no transcript parsing of its own and no
 sqlite-vec extension — a plain sqlite3 connection suffices.
 """
 
+import re
 import sqlite3
 import subprocess
 from dataclasses import dataclass, field
@@ -25,6 +26,12 @@ from .config import PROJECT_ALL, PROJECT_GIT, Watermarks
 
 MAX_CALL_CHARS = 60_000    # per-CALL ceiling: chapter split for marathon sessions
 MAX_TURN_CHARS = 4_000     # one pasted log must not eat a whole chapter
+
+# A "project" whose name is a bare UUID is index junk (a session recorded from
+# some odd cwd), never a real codebase — the first all-projects backfill burned
+# calls distilling several of these into UUID-named folders.
+_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.I)
 
 
 @dataclass
@@ -63,9 +70,11 @@ def select_projects(db: sqlite3.Connection, selector: list,
         "SELECT project, MAX(cwd) FROM chunks WHERE project != '' "
         "GROUP BY project").fetchall()
     if PROJECT_ALL in selector:
-        return sorted(p for p, _ in rows)
+        return sorted(p for p, _ in rows if not _UUID_RE.match(p))
     if PROJECT_GIT in selector:
-        return sorted(p for p, cwd in rows if cwd and is_git(cwd))
+        return sorted(p for p, cwd in rows
+                      if not _UUID_RE.match(p) and cwd and is_git(cwd))
+    # explicit names are deliberate — no junk filter applied
     wanted = set(selector)
     return sorted(p for p, _ in rows if p in wanted)
 

--- a/tests/test_metadocs.py
+++ b/tests/test_metadocs.py
@@ -100,6 +100,18 @@ def test_select_projects_git_probes_cwd(db, marks):
     assert collect.select_projects(db, ["no-git"]) == ["no-git"]
 
 
+def test_select_projects_skips_uuid_junk(db, marks):
+    """A bare-UUID "project" is a session with an odd cwd, not a codebase —
+    all/git never distill it; only naming it explicitly does."""
+    junk = "bcb3fb67-e6e9-4d51-af40-83fdd5986ff9"
+    add_turn(db, junk, "user", "x", 1, cwd="/tmp/x")
+    add_turn(db, "real", "user", "x", 1, cwd="/tmp/real")
+    assert collect.select_projects(db, [PROJECT_ALL]) == ["real"]
+    assert collect.select_projects(db, [PROJECT_GIT],
+                                   is_git=lambda c: True) == ["real"]
+    assert collect.select_projects(db, [junk]) == [junk]
+
+
 # -- distill output protocol --------------------------------------------------
 def test_parse_file_blocks():
     raw = ("=== FILE: bugs.md ===\n# Bugs\n- one\n"


### PR DESCRIPTION
The first all-projects backfill distilled several sessions whose project
name is a raw session UUID (odd cwd at record time) into UUID-named
folders, burning calls on noise. all/git now filter them; naming a UUID
explicitly still works, deliberate choice wins.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
