### PR TITLE
feat(metadocs): entries join the main search index as source="metadocs"

### DIFF
--- a/src/session_recall/cli.py
+++ b/src/session_recall/cli.py
@@ -113,13 +113,24 @@ def main(argv=None):
         claude_root = config.CLAUDE_PROJECTS if args.source in {"all", "claude"} else None
         codex_roots = ((config.CODEX_SESSIONS, config.CODEX_ARCHIVED_SESSIONS)
                        if args.source in {"all", "codex"} else ())
+        embedder = make_embedder()
         n = index_corpus(
             store,
-            make_embedder(),
+            embedder,
             claude_root,
             codex_dirs=codex_roots,
         )
         print(f"indexed {n} chunks from changed transcripts")
+        # meta docs entries ride the same index (source="metadocs") whenever
+        # the feature is configured; the SessionStart hook keeps them fresh
+        if args.source == "all":
+            from .metadocs import config as md_config
+            md_cfg = md_config.load()
+            if md_cfg is not None:
+                from .metadocs.indexing import index_metadocs
+                m = index_metadocs(store, embedder, Path(md_cfg.repo).expanduser())
+                if m:
+                    print(f"indexed {m} meta docs entr(y/ies)")
         _print_corpus_summary(store)
     elif args.cmd == "search":
         recall = Recall(store, make_embedder(), make_reranker())

--- a/src/session_recall/metadocs/cli.py
+++ b/src/session_recall/metadocs/cli.py
@@ -38,8 +38,8 @@ def add_parser(sub) -> None:
                     help="agent model (default: the claude CLI's own default); "
                          "the distiller never picks a model on its own")
     ip.add_argument("--from-today", action="store_true",
-                    help="start the memory now: dialogue older than this "
-                         "moment is never distilled")
+                    help="start the memory today: dialogue from before local "
+                         "midnight is never distilled")
     ip.add_argument("--push", action="store_true",
                     help="push after each commit (default: commit stays local)")
     msub.add_parser("run", help="distill everything new right now")
@@ -55,11 +55,18 @@ def run(args: argparse.Namespace) -> int:
         if not _TIME_RE.match(args.daily_at):
             print(f"--daily-at must be HH:MM, got {args.daily_at!r}")
             return 1
+        if args.from_today:
+            # local midnight, not "this second": «с сегодняшнего дня» includes
+            # the sessions already run today
+            lt = time.localtime()
+            since = time.mktime((lt.tm_year, lt.tm_mon, lt.tm_mday,
+                                 0, 0, 0, 0, 0, -1))
+        else:
+            since = 0.0
         cfg = MetaConfig(repo=str(Path(args.repo).expanduser()),
                          projects=list(args.projects),
                          daily_at=args.daily_at, push=bool(args.push),
-                         model=args.model,
-                         since=time.time() if args.from_today else 0.0)
+                         model=args.model, since=since)
         md_config.save(cfg)
         sel = ("every indexed project" if PROJECT_ALL in cfg.projects else
                "every project with a git checkout" if PROJECT_GIT in cfg.projects

--- a/src/session_recall/metadocs/indexing.py
+++ b/src/session_recall/metadocs/indexing.py
@@ -1,0 +1,83 @@
+"""Feed meta docs entries into the main search index as source="metadocs".
+
+This is the retrieval half of the design: within a project an agent reads the
+entry files whole (they are small by construction), but across projects —
+«где я уже чинил похожий баг?» — search must work, and the entries are ideal
+retrieval chunks: deduplicated, structured, provenance-carrying. They join
+the same vector+FTS index the transcripts live in, so `recall_search` and the
+MCP tools find them with zero new machinery; `source="metadocs"` filters.
+
+Incremental exactly like transcripts: one entry file = one indexed unit,
+keyed by mtime/size signature with the embed fingerprint baked in; edits
+re-embed one entry, deletions fall out via prune (path gone from disk).
+"""
+
+import hashlib
+import time
+from pathlib import Path
+
+from ..models import Chunk
+from ..store import Store
+from . import entries
+
+_SIG_TAG = "metadocs-v1"
+
+
+def _embed_fp() -> str:
+    from .. import config
+    return f"{config.EMBED_PROVIDER}/{config.EMBED_MODEL}/{config.EMBED_DIM}"
+
+
+def _entry_files(repo: Path):
+    yield from repo.glob(f"{entries.USER_DIR}/*.md")
+    for category in ("bugs", "actions", "decisions"):
+        yield from repo.glob(f"*/{category}/*.md")
+
+
+def _ts(date_str: str) -> int:
+    try:
+        return int(time.mktime(time.strptime(date_str, "%Y-%m-%d")))
+    except (ValueError, OverflowError):
+        return int(time.time())
+
+
+def _chunk(entry: entries.Entry, path: Path, text: str) -> Chunk:
+    return Chunk(
+        session_id=entry.id, uuid=entry.id, role="doc", text=text,
+        project=entry.project or "user-map", cwd="", git_branch="",
+        ts=_ts(entry.updated or entry.created), file_path=str(path),
+        byte_offset=0, byte_len=len(text.encode()), turn_index=0,
+        content_hash=hashlib.sha256(text.encode()).hexdigest(),
+        source="metadocs")
+
+
+def index_metadocs(store: Store, embedder, repo: Path) -> int:
+    """Index changed entries; returns how many were (re)indexed."""
+    if not repo.is_dir():
+        return 0
+    count = 0
+    for path in sorted(_entry_files(repo)):
+        st = path.stat()
+        sig = f"{_SIG_TAG}:{_embed_fp()}:{int(st.st_mtime)}:{st.st_size}"
+        if store.is_indexed(str(path), sig):
+            continue
+        entry = entries.parse(path.read_text())
+        if entry is None:
+            continue          # half-written or foreign file: skip, no marker
+        text = f"{entry.title}\n\n{entry.body}"
+        cached = store.embeddings_by_hash(str(path))
+        chunk = _chunk(entry, path, text)
+        try:
+            vec = cached.get(chunk.content_hash)
+            if vec is None:
+                (vec,) = embedder.embed_documents([text])
+            store.delete_file(str(path))
+            store.add(chunk, vec)
+            store.mark_indexed(str(path), sig, source="metadocs")
+            store.commit()
+            count += 1
+        except Exception:
+            store.rollback()
+            raise
+    store.prune_deleted(source="metadocs")
+    return count

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,6 +13,7 @@ def test_cli_index_then_search(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(config, "CODEX_SESSIONS", tmp_path / "no-codex-sessions")
     monkeypatch.setattr(config, "CODEX_ARCHIVED_SESSIONS", tmp_path / "no-codex-archive")
     monkeypatch.setattr(config, "DB_PATH", tmp_path / "cli.db")
+    monkeypatch.setattr(config, "DATA_DIR", tmp_path / "data")  # keep the live metadocs config out of the test
     monkeypatch.setattr(cli, "make_embedder", lambda: FakeEmbedder())
     monkeypatch.setattr(cli, "make_reranker", lambda: __import__("session_recall.rerank", fromlist=["FakeReranker"]).FakeReranker())
     cli.main(["index"])
@@ -31,6 +32,7 @@ def test_cli_recent_grep_prune(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(config, "CODEX_SESSIONS", tmp_path / "no-codex-sessions")
     monkeypatch.setattr(config, "CODEX_ARCHIVED_SESSIONS", tmp_path / "no-codex-archive")
     monkeypatch.setattr(config, "DB_PATH", tmp_path / "cli.db")
+    monkeypatch.setattr(config, "DATA_DIR", tmp_path / "data")  # keep the live metadocs config out of the test
     monkeypatch.setattr(cli, "make_embedder", lambda: FakeEmbedder())
     monkeypatch.setattr(cli, "make_reranker", lambda: None)
     cli.main(["index"])

--- a/tests/test_metadocs.py
+++ b/tests/test_metadocs.py
@@ -387,6 +387,65 @@ def test_run_commit_per_project(db, tmp_path, repo, monkeypatch):
     assert [c[0] for c in report.commits] == ["other", "proj"]
 
 
+# -- search index integration -------------------------------------------------
+class _FakeStore:
+    def __init__(self):
+        self.indexed, self.chunks, self.pruned = {}, [], 0
+
+    def is_indexed(self, path, sig):
+        return self.indexed.get(path) == sig
+
+    def embeddings_by_hash(self, path):
+        return {}
+
+    def delete_file(self, path):
+        self.chunks = [c for c in self.chunks if c.file_path != path]
+
+    def add(self, chunk, vec):
+        self.chunks.append(chunk)
+
+    def mark_indexed(self, path, sig, source="claude"):
+        self.indexed[path] = sig
+
+    def prune_deleted(self, source=None):
+        self.pruned += 1
+        return 0
+
+    def commit(self):
+        pass
+
+    def rollback(self):
+        pass
+
+
+class _FakeEmbedder:
+    def embed_documents(self, texts):
+        return [b"\x00" * 4 for _ in texts]
+
+
+def test_entries_join_the_index_as_metadocs_source(repo):
+    from session_recall.metadocs.indexing import index_metadocs
+    entries.save(repo, Entry(id="bug-idx001", project="proj", category="bugs",
+                             title="таймаут", body="лечили так"))
+    entries.save(repo, Entry(id="use-idx002", project="", category="user",
+                             title="карта", body="secrets в Doppler"))
+    store = _FakeStore()
+    n = index_metadocs(store, _FakeEmbedder(), repo)
+    assert n == 2
+    assert {c.source for c in store.chunks} == {"metadocs"}
+    assert {c.project for c in store.chunks} == {"proj", "user-map"}
+    assert all(c.role == "doc" for c in store.chunks)
+    # unchanged files are skipped on the next sweep; an edit re-indexes one
+    assert index_metadocs(store, _FakeEmbedder(), repo) == 0
+    e = entries.load(repo, "bug-idx001")
+    e.body = "дополнили"
+    entries.save(repo, e)
+    import os as _os
+    _os.utime(entries.entry_path(repo, e),
+              (entries.entry_path(repo, e).stat().st_mtime + 2,) * 2)
+    assert index_metadocs(store, _FakeEmbedder(), repo) == 1
+
+
 # -- single-run lock ----------------------------------------------------------
 def test_second_run_steps_aside_while_first_holds_lock(tmp_path):
     fd = run_mod.acquire_lock(tmp_path)


### PR DESCRIPTION
The retrieval half of the design: within a project an agent reads the entry
files whole (small by construction), but across projects — «где я уже чинил
похожий баг?» — needs search. Entries are ideal retrieval chunks
(deduplicated, structured, provenance-carrying), so they ride the existing
vector+FTS index with zero new machinery: `session-recall index` sweeps the
metadocs repo whenever the feature is configured, recall_search and the MCP
tools find entries alongside transcripts, and source="metadocs" filters.
Incremental like transcripts: mtime/size+embed-fingerprint signatures, an
edit re-embeds one entry, deletions fall out via prune.

Also: --from-today now means local MIDNIGHT, not "this second" — «с
сегодняшнего дня» includes the sessions already run today. And test_cli now
pins DATA_DIR into the tmp dir: the new index integration read the LIVE
metadocs config inside the test, which is exactly the behavior users want
and exactly what a hermetic test must not do.

Suite: 307 passed.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
