### PR TITLE
feat(metadocs): explicit `index-history` — the daily job never touches the past

### DIFF
--- a/src/session_recall/metadocs/cli.py
+++ b/src/session_recall/metadocs/cli.py
@@ -43,6 +43,17 @@ def add_parser(sub) -> None:
     ip.add_argument("--push", action="store_true",
                     help="push after each commit (default: commit stays local)")
     msub.add_parser("run", help="distill everything new right now")
+    hp = msub.add_parser(
+        "index-history",
+        help="one-shot: distill OLD sessions into the memory; the daily job "
+             "never touches history, this command is the only way in")
+    hp.add_argument("--from", dest="from_date", metavar="YYYY-MM-DD",
+                    help="start of the history window (default: the beginning)")
+    hp.add_argument("--until", dest="until_date", metavar="YYYY-MM-DD",
+                    help="last day of the window, inclusive (default: up to "
+                         "where the daily memory starts — nothing twice)")
+    hp.add_argument("--days", type=int, default=None,
+                    help="shorthand: the last N days before the daily memory")
     msub.add_parser("enable", help="turn the daily job on (launchd)")
     msub.add_parser("disable", help="turn the daily job off")
     msub.add_parser("status", help="show config, schedule and progress")
@@ -107,7 +118,7 @@ def run(args: argparse.Namespace) -> int:
             print(f"--- log tail ---\n{tail.strip()}")
         return 0
 
-    if cmd == "run":
+    if cmd in ("run", "index-history"):
         import os as _os
         from .run import acquire_lock
         distiller = make_distiller(cfg.engine, cfg.repo, model=cfg.model)
@@ -117,15 +128,37 @@ def run(args: argparse.Namespace) -> int:
         if not app_config.DB_PATH.exists():
             print(f"no index at {app_config.DB_PATH} — run: session-recall index")
             return 1
+
+        since, until = None, None
+        if cmd == "index-history":
+            # history ends where the daily memory begins, unless said otherwise
+            until = cfg.since or None
+            since = 0.0
+            if args.days is not None:
+                since = (until or time.time()) - args.days * 86400
+            if args.from_date or args.until_date:
+                from ..timefmt import date_range_to_epoch
+                try:
+                    start_ts, end_ts = date_range_to_epoch(
+                        args.from_date, args.until_date, None)
+                except ValueError as exc:
+                    print(exc)
+                    return 1
+                since = float(start_ts) if start_ts is not None else since
+                until = float(end_ts) if end_ts is not None else until
+            span = (f"{args.from_date or 'the beginning'} → "
+                    f"{args.until_date or 'start of daily memory'}")
+            print(f"distilling history: {span}")
+
         lock_fd = acquire_lock(app_config.DATA_DIR)
         if lock_fd is None:
             # exit 0 on purpose: the overlap is expected (nightly job vs a long
-            # manual backfill), and the other run is doing this run's work
+            # manual history pass), and the other run is doing this run's work
             print("another meta docs run is already in progress — stepping aside")
             return 0
         db = open_index(app_config.DB_PATH)
         try:
-            report = run_once(cfg, db, distiller)
+            report = run_once(cfg, db, distiller, since=since, until=until)
         finally:
             db.close()
             _os.close(lock_fd)

--- a/src/session_recall/metadocs/collect.py
+++ b/src/session_recall/metadocs/collect.py
@@ -80,11 +80,14 @@ def select_projects(db: sqlite3.Connection, selector: list,
 
 
 def pending_sessions(db: sqlite3.Connection, project: str, marks: Watermarks,
-                     since: float = 0.0) -> list[SessionUpdate]:
+                     since: float = 0.0,
+                     until: float | None = None) -> list[SessionUpdate]:
     """Every session with dialogue newer than its watermark, oldest first.
     A late-indexed old session has no mark and is picked up whole; an appended
     session contributes only its tail — «обновления по сессии». `since` is the
-    config's start-of-memory: dialogue older than it is nobody's backlog."""
+    start-of-memory (dialogue older than it is nobody's backlog); `until` caps
+    the window from above — `index-history` uses it to stop exactly where the
+    daily memory begins, so the two never overlap."""
     rows = db.execute(
         "SELECT source, session_id, role, text, ts FROM chunks "
         "WHERE project = ? AND role IN ('user', 'assistant') "
@@ -95,7 +98,9 @@ def pending_sessions(db: sqlite3.Connection, project: str, marks: Watermarks,
         if not text or not text.strip():
             continue
         ts = int(ts or 0)
-        if ts < since or ts <= marks.last_ts(source, sid):
+        if ts < since or (until is not None and ts >= until):
+            continue
+        if ts <= marks.last_ts(source, sid):
             continue
         upd = per.setdefault(f"{source}:{sid}",
                              SessionUpdate(source=source, session_id=sid))

--- a/src/session_recall/metadocs/run.py
+++ b/src/session_recall/metadocs/run.py
@@ -51,7 +51,11 @@ class RunReport:
 
 
 def run_once(cfg: MetaConfig, db, distiller: Distiller,
-             data_dir: Path | None = None) -> RunReport:
+             data_dir: Path | None = None, since: float | None = None,
+             until: float | None = None) -> RunReport:
+    """The daily run distills [cfg.since, now); `metadocs index-history`
+    passes explicit since/until to distill an older window on demand — same
+    watermarks, so the two can never double-process a session."""
     repo = Path(cfg.repo).expanduser()
     ensure_repo(repo)
     marks = Watermarks(state_path(data_dir))
@@ -62,7 +66,9 @@ def run_once(cfg: MetaConfig, db, distiller: Distiller,
         commit(repo, "meta docs: migrate to entry-per-file format")
 
     for project in collect.select_projects(db, cfg.projects):
-        sessions = collect.pending_sessions(db, project, marks, since=cfg.since)
+        sessions = collect.pending_sessions(
+            db, project, marks,
+            since=cfg.since if since is None else since, until=until)
         if not sessions:
             continue
         done, note = 0, ""

--- a/tests/test_metadocs.py
+++ b/tests/test_metadocs.py
@@ -258,6 +258,30 @@ def test_collect_since_cuts_history(db, marks):
     assert collect.pending_sessions(db, "p", marks, since=1000) == []
 
 
+def test_collect_window_for_history(db, marks):
+    """index-history distills [since, until): the cap is where the daily
+    memory starts, so the two paths can never double-process."""
+    add_turn(db, "p", "user", "старое", 100, sid="s1")
+    add_turn(db, "p", "user", "в окне", 500, sid="s2")
+    add_turn(db, "p", "user", "уже дневное", 900, sid="s3")
+    got = collect.pending_sessions(db, "p", marks, since=300, until=900)
+    assert [u.session_id for u in got] == ["s2"]
+
+
+def test_history_and_daily_share_watermarks(db, tmp_path, repo, monkeypatch):
+    """A session distilled by the daily run is invisible to a later history
+    pass — same marks, no double work."""
+    monkeypatch.setattr("session_recall.metadocs.run.state_path",
+                        lambda d=None: tmp_path / "st.json")
+    add_turn(db, "proj", "user", "сегодняшняя работа", 900)
+    cfg = MetaConfig(repo=str(repo), projects=[PROJECT_ALL], since=800)
+    seen = []
+    distiller = lambda p, k, t: seen.append((k, t[0]["text"])) or True
+    run_once(cfg, db, distiller)                          # daily
+    run_once(cfg, db, distiller, since=0.0, until=None)   # history over ALL
+    assert seen == [("claude:sess-1", "сегодняшняя работа")]
+
+
 def test_collect_sessions_ordered_oldest_first(db, marks):
     add_turn(db, "p", "user", "later story", 300, sid="s2")
     add_turn(db, "p", "user", "earlier story", 100, sid="s1")


### PR DESCRIPTION
Maxim's split: the cron distills strictly from today; history gets in ONLY
through a deliberate one-shot command. `metadocs index-history` distills an
older window — --from/--until (inclusive local dates), --days N, default
"everything up to where the daily memory starts". The window cap defaults
to cfg.since and both paths share the per-session watermarks, so a session
can never be distilled twice no matter how the two are interleaved. Same
flock, same agent, same commits-per-project.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
