### PR TITLE
fix(metadocs): the distiller must not eat its own exhaust — mkdtemp projects are junk

### DIFF
--- a/src/session_recall/metadocs/collect.py
+++ b/src/session_recall/metadocs/collect.py
@@ -27,11 +27,15 @@ from .config import PROJECT_ALL, PROJECT_GIT, Watermarks
 MAX_CALL_CHARS = 60_000    # per-CALL ceiling: chapter split for marathon sessions
 MAX_TURN_CHARS = 4_000     # one pasted log must not eat a whole chapter
 
-# A "project" whose name is a bare UUID is index junk (a session recorded from
-# some odd cwd), never a real codebase — the first all-projects backfill burned
-# calls distilling several of these into UUID-named folders.
-_UUID_RE = re.compile(
-    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.I)
+# A "project" whose name is a bare UUID or an mkdtemp basename is index junk,
+# never a real codebase. The tmp pattern is load-bearing: print-mode agent
+# calls (the distiller itself, the share composer) run in temp dirs and leave
+# transcripts there — without this filter the distiller EATS ITS OWN EXHAUST,
+# distilling transcripts of previous distill calls in a self-feeding loop
+# (observed live: 360 tmp "projects" in one evening).
+_JUNK_RE = re.compile(
+    r"^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+    r"|tmp[-_a-z0-9]{8})$", re.I)   # mkdtemp: tmp + exactly 8 random chars
 
 
 @dataclass
@@ -70,10 +74,10 @@ def select_projects(db: sqlite3.Connection, selector: list,
         "SELECT project, MAX(cwd) FROM chunks WHERE project != '' "
         "GROUP BY project").fetchall()
     if PROJECT_ALL in selector:
-        return sorted(p for p, _ in rows if not _UUID_RE.match(p))
+        return sorted(p for p, _ in rows if not _JUNK_RE.match(p))
     if PROJECT_GIT in selector:
         return sorted(p for p, cwd in rows
-                      if not _UUID_RE.match(p) and cwd and is_git(cwd))
+                      if not _JUNK_RE.match(p) and cwd and is_git(cwd))
     # explicit names are deliberate — no junk filter applied
     wanted = set(selector)
     return sorted(p for p, _ in rows if p in wanted)

--- a/tests/test_metadocs.py
+++ b/tests/test_metadocs.py
@@ -356,12 +356,17 @@ def test_select_projects_git_probes_cwd(db, marks):
     assert collect.select_projects(db, ["no-git"]) == ["no-git"]
 
 
-def test_select_projects_skips_uuid_junk(db, marks):
-    junk = "bcb3fb67-e6e9-4d51-af40-83fdd5986ff9"
-    add_turn(db, junk, "user", "x", 1, cwd="/tmp/x")
+def test_select_projects_skips_junk(db, marks):
+    """UUID projects and mkdtemp projects are index noise. The tmp filter is
+    what breaks the self-feeding loop: distill calls leave transcripts in temp
+    dirs, and without it the distiller distills its own exhaust."""
+    for junk in ("bcb3fb67-e6e9-4d51-af40-83fdd5986ff9", "tmpbclhg-1i",
+                 "tmp-17t6dtr", "tmpb_890sfv"):
+        add_turn(db, junk, "user", "x", 1, cwd="/tmp/x", sid=junk)
     add_turn(db, "real", "user", "x", 1, cwd="/tmp/real")
-    assert collect.select_projects(db, [PROJECT_ALL]) == ["real"]
-    assert collect.select_projects(db, [junk]) == [junk]
+    add_turn(db, "tmpserver", "user", "x", 1, cwd="/tmp/t")  # not mkdtemp-shaped
+    assert collect.select_projects(db, [PROJECT_ALL]) == ["real", "tmpserver"]
+    assert collect.select_projects(db, ["tmpbclhg-1i"]) == ["tmpbclhg-1i"]
 
 
 # -- the whole run ------------------------------------------------------------


### PR DESCRIPTION
Observed live: print-mode agent calls (the distiller itself, the share
composer) run in temp dirs and leave transcripts there; those transcripts
get indexed as tmpXXXXXXXX "projects" with fresh timestamps, and the next
run distills them — a self-feeding loop that manufactured 360 junk projects
in one evening and burned subscription calls on transcripts of its own
calls. all/git selectors now skip mkdtemp-shaped names (tmp + exactly 8
random chars) alongside bare UUIDs; explicit naming still works. The codex
engine also breaks the loop at the source (--ephemeral writes no
transcript); the claude engine still writes them, so the filter is
load-bearing, not belt-and-suspenders.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
