### PR TITLE
feat(share): no baked-in relay — transport is the peers' explicit choice

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,9 +308,76 @@ Privacy here is mechanics, not policy:
   the owner (Telegram bot, or `share approve` locally) before it leaves the machine;
 - a contact can be paused any time (`share pause`), a peer revoked (`share revoke`).
 
+### Pick a transport (once, before pairing)
+
+Nothing is baked in: a fresh install has **no transport** and never talks to a
+server you didn't choose. The relay is blind — everything it carries is sealed
+and signed on the clients — so which one to use is coordination between peers,
+not a matter of trust. Three recipes, simplest first:
+
+**Shared folder — zero infrastructure.** Two accounts on one machine, or any
+folder both peers sync (Syncthing, Dropbox, an NFS mount):
+
+```bash
+export SESSION_RECALL_SHARE_TRANSPORT_DIR=~/Sync/sr-share   # both peers, same folder
+```
+
+**Your relay on the LAN.** One machine runs it, everyone points at it.
+Envelopes are end-to-end encrypted regardless, but this is plain HTTP —
+mailbox addresses travel readable, so keep it to a network you trust:
+
+```bash
+session-recall share relay --port 8787 --host 0.0.0.0       # on the relay machine
+export SESSION_RECALL_RELAY_URL=http://192.168.1.20:8787    # on every peer
+```
+
+**Your relay on the internet.** The relay binds localhost on purpose and
+expects a TLS terminator in front. On the server:
+
+```bash
+pipx install git+https://github.com/AbsoluteMode/session-recall
+session-recall share relay --port 8787    # binds 127.0.0.1
+```
+
+As a user systemd service (`~/.config/systemd/user/sr-relay.service`):
+
+```ini
+[Unit]
+Description=session-recall share relay
+
+[Service]
+ExecStart=%h/.local/bin/session-recall share relay --port 8787
+Restart=on-failure
+
+[Install]
+WantedBy=default.target
+```
+
+```bash
+systemctl --user enable --now sr-relay
+loginctl enable-linger $USER              # keep it alive after logout
+```
+
+Any TLS proxy in front works; Caddy is the two-line option:
+
+```
+relay.example.com {
+    reverse_proxy 127.0.0.1:8787
+}
+```
+
+Then on every peer: `export SESSION_RECALL_RELAY_URL=https://relay.example.com`.
+The relay stores only sealed blobs under `<data-dir>/share-relay`, and a
+mailbox is emptied on fetch; `SESSION_RECALL_RELAY_URL=none` keeps an install
+network-silent on purpose. Put the `export` in your shell profile so agents
+and timers see it too.
+
+### Pairing
+
 Pairing is a one-time ceremony with a short SAS check, then asking is one command:
 
 ```bash
+export SESSION_RECALL_RELAY_URL=https://relay.example.com   # both sides: the transport you picked
 session-recall share init            # once per device, both sides
 session-recall share invite          # you: prints a one-time code
 session-recall share join <code>     # colleague: accepts it

--- a/src/session_recall/share/cli.py
+++ b/src/session_recall/share/cli.py
@@ -17,9 +17,10 @@ from .transport import from_env
 from .trust import Peer, TrustStore
 
 _TRANSPORT_HINT = (
-    "transport disabled (SESSION_RECALL_RELAY_URL=none) — unset it to use the "
-    "default relay, set it to your own relay, or set "
-    "SESSION_RECALL_SHARE_TRANSPORT_DIR for a shared folder")
+    "no transport configured — set SESSION_RECALL_RELAY_URL to your relay "
+    "(README → Team mode has LAN and self-host recipes), or "
+    "SESSION_RECALL_SHARE_TRANSPORT_DIR to a folder both peers sync; "
+    "SESSION_RECALL_RELAY_URL=none keeps this install offline on purpose")
 
 
 def add_parser(sub) -> None:

--- a/src/session_recall/share/transport.py
+++ b/src/session_recall/share/transport.py
@@ -119,29 +119,27 @@ class HttpRelayTransport:
         return [base64.b64decode(i) for i in items]
 
 
-# The public relay every fresh install talks to, so onboarding is
-# `share init` → `share invite` with zero configuration. Baking it in is safe
-# because the relay is blind: everything it carries is sealed and signed
-# client-side, so WHICH relay both sides use is coordination, not trust — and a
-# built-in default is the one value two strangers already agree on.
+# No relay is baked in: an open-source install must never talk to a server
+# its user did not choose — not even a blind one. WHICH transport two peers
+# use is coordination they settle when they pair (the relay only ever carries
+# blobs sealed and signed client-side, so the choice is about metadata and
+# availability, not message trust).
 #
-# Deliberately NOT taken from the pairing bundle: a bundle is peer-supplied
-# data, and a relay URL inside it would let a malicious bundle point this
-# client at an attacker's server. Changing relays is manual by design.
-DEFAULT_RELAY_URL = "https://relay.terra-sandbox.ru"
+# Deliberately NOT taken from the pairing bundle either: a bundle is
+# peer-supplied data, and a relay URL inside it would let a malicious bundle
+# point this client at an attacker's server. Configuring the transport is
+# manual by design.
 
 
 def from_env(env: dict, identity=None) -> Transport | None:
-    """Explicit relay URL wins; a shared directory is the zero-infra fallback;
-    otherwise the public relay. `SESSION_RECALL_RELAY_URL=none` (or `off`)
-    disables the relay — with no directory configured that means no transport
-    at all, for installs that must never speak to the network."""
+    """Explicit relay URL wins; a shared directory is the zero-infra
+    alternative; nothing configured means NO transport at all — the CLI
+    surfaces what to set. `SESSION_RECALL_RELAY_URL=none` (or `off`)
+    disables the relay while leaving a configured directory usable."""
     url = (env.get("SESSION_RECALL_RELAY_URL") or "").strip()
     if url and url.lower() not in ("none", "off"):
         return HttpRelayTransport(url, identity=identity)
     root = env.get("SESSION_RECALL_SHARE_TRANSPORT_DIR")
     if root:
         return FileTransport(Path(root))
-    if url:                      # explicit none/off, nothing else configured
-        return None
-    return HttpRelayTransport(DEFAULT_RELAY_URL, identity=identity)
+    return None

--- a/tests/test_share_cli.py
+++ b/tests/test_share_cli.py
@@ -103,12 +103,14 @@ def test_commands_without_identity_point_to_init(homes, capsys):
     assert "share init" in capsys.readouterr().out
 
 
-def test_transport_opt_out_hint(homes, capsys, monkeypatch):
-    """With a built-in default relay the only path to "no transport" is the
-    explicit opt-out — and it must say how to get back."""
+def test_no_transport_hint_says_what_to_set(homes, capsys, monkeypatch):
+    """No transport is the fresh-install default now — the failure must teach
+    the fix (which env var, where the recipes live), not just refuse."""
     monkeypatch.delenv("SESSION_RECALL_SHARE_TRANSPORT_DIR", raising=False)
-    monkeypatch.setenv("SESSION_RECALL_RELAY_URL", "none")
+    monkeypatch.delenv("SESSION_RECALL_RELAY_URL", raising=False)
     homes("maxim")
     _run(["share", "init", "maxim"])
     assert _run(["share", "invite"]) == 1
-    assert "transport disabled" in capsys.readouterr().out
+    out = capsys.readouterr().out
+    assert "no transport configured" in out
+    assert "SESSION_RECALL_RELAY_URL" in out

--- a/tests/test_share_transport.py
+++ b/tests/test_share_transport.py
@@ -1,14 +1,13 @@
-"""Transport selection: explicit env wins, the public relay is the default
-(zero-config onboarding), and `none` opts out of the network entirely."""
+"""Transport selection: explicit env wins, nothing configured means no
+transport at all (an install never talks to a server its user didn't choose),
+and `none` opts out of the network entirely."""
 
 from session_recall.share.transport import (
-    DEFAULT_RELAY_URL, FileTransport, HttpRelayTransport, from_env)
+    FileTransport, HttpRelayTransport, from_env)
 
 
-def test_default_is_the_public_relay():
-    t = from_env({})
-    assert isinstance(t, HttpRelayTransport)
-    assert t.base == DEFAULT_RELAY_URL.rstrip("/")
+def test_unconfigured_means_no_transport():
+    assert from_env({}) is None
 
 
 def test_explicit_url_wins(tmp_path):
@@ -17,7 +16,7 @@ def test_explicit_url_wins(tmp_path):
     assert isinstance(t, HttpRelayTransport) and t.base == "https://my.example"
 
 
-def test_shared_dir_beats_the_default(tmp_path):
+def test_shared_dir_is_the_zero_infra_path(tmp_path):
     assert isinstance(from_env(
         {"SESSION_RECALL_SHARE_TRANSPORT_DIR": str(tmp_path)}), FileTransport)
 


### PR DESCRIPTION
`DEFAULT_RELAY_URL` pointed every fresh install at our relay. For an open-source project that's wrong twice: users' machines silently talk to a stranger's server (blind to content, but metadata and availability are real), and our box carries every install's traffic.

Now:
- **nothing configured → no transport at all**; `share` commands fail with a hint that teaches the fix (`SESSION_RECALL_RELAY_URL` / `SESSION_RECALL_SHARE_TRANSPORT_DIR`, pointer to README recipes);
- `none`/`off` semantics unchanged (explicit network-silence; a configured shared folder still works alongside);
- README **Team mode → Pick a transport**: three recipes, simplest first — shared synced folder (zero infra), LAN relay (`--host 0.0.0.0`, plain-HTTP caveat), self-hosted relay (localhost bind + systemd user unit + Caddy/any TLS proxy in front); mailbox semantics documented (sealed blobs only, emptied on fetch).

Tests updated: fresh-env selection returns `None`; the CLI hint test asserts the teaching message. Suite 312 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)