### PR TITLE
feat(cli): setup — the onboarding that asks the language

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,12 @@ agent. Budget about two minutes plus the first index run.
 
 ```bash
 pipx install git+https://github.com/AbsoluteMode/session-recall
-session-recall index   # first run walks your whole history; later runs are incremental
+session-recall setup   # one question (interaction language), then the first index
 ```
+
+`setup` is optional sugar — `session-recall index` directly works too, every
+setting has a default. The first run walks your whole history; later runs are
+incremental. Scripted installs: `session-recall setup --lang en --yes`.
 
 That is the whole thing: with no key and no local server, indexing runs on a
 bundled CPU model, downloaded once and picked by your interaction language

--- a/src/session_recall/cli.py
+++ b/src/session_recall/cli.py
@@ -99,12 +99,16 @@ def main(argv=None):
     share_cli.add_parser(sub)
     from .metadocs import cli as metadocs_cli
     metadocs_cli.add_parser(sub)
+    from . import onboarding
+    onboarding.add_parser(sub)
     args = parser.parse_args(argv)
 
     if args.cmd == "share":  # no Store: share state lives outside the index DB
         return share_cli.run(args)
     if args.cmd == "metadocs":  # reads the index read-only via plain sqlite3
         return metadocs_cli.run(args)
+    if args.cmd == "setup":  # indexes via a child process (fresh env resolve)
+        return onboarding.run(args)
 
     store = Store(config.DB_PATH)
     if args.cmd == "health":

--- a/src/session_recall/onboarding.py
+++ b/src/session_recall/onboarding.py
@@ -1,0 +1,96 @@
+"""`session-recall setup` — the one-time project onboarding.
+
+Asks the question that steers defaults — the interaction language, which
+picks the bundled embedding model — records the answer in the settings file,
+shows what the environment resolves to, and offers to run the first index.
+Safe to re-run: it edits settings, it never wipes anything.
+
+The index runs as a child process on purpose: embed settings resolve at
+import time, so only a fresh process sees the language this command just
+stored.
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from . import config
+
+_PROMPT = ("Interaction language — steers the bundled embedding model "
+           "[en/zh/ru/…, Enter = multilingual]: ")
+
+
+def add_parser(sub) -> None:
+    p = sub.add_parser(
+        "setup", help="one-time onboarding: language, embedder, first index")
+    p.add_argument("--lang", help="interaction language (skips the question)")
+    p.add_argument("--yes", action="store_true",
+                   help="non-interactive: accept defaults and run the first index")
+
+
+def _store_lang(lang: str) -> None:
+    """Read-modify-write: setup owns one key, whatever else lives in the
+    settings file stays."""
+    settings = {}
+    try:
+        settings = json.loads(config.SETTINGS_PATH.read_text())
+    except (OSError, ValueError):
+        pass
+    settings["lang"] = lang
+    config.SETTINGS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    config.SETTINGS_PATH.write_text(json.dumps(settings, indent=2) + "\n")
+
+
+def _transcript_footprint() -> tuple[int, int]:
+    """How much history is waiting — the first index on the bundled CPU model
+    is minutes-per-months, and saying so beats looking hung."""
+    files, size = 0, 0
+    for root in (config.CLAUDE_PROJECTS, config.CODEX_SESSIONS,
+                 config.CODEX_ARCHIVED_SESSIONS):
+        root = Path(root)
+        if not root.is_dir():
+            continue
+        for p in root.rglob("*.jsonl"):
+            files += 1
+            try:
+                size += p.stat().st_size
+            except OSError:
+                pass
+    return files, size
+
+
+def _run_index() -> int:
+    return subprocess.run([sys.executable, "-m", "session_recall.cli",
+                           "index"]).returncode
+
+
+def run(args: argparse.Namespace, index_cmd=_run_index,
+        ask=input, is_tty=None) -> int:
+    interactive = (sys.stdin.isatty() if is_tty is None else is_tty) and not args.yes
+
+    lang = (args.lang or "").strip().lower()
+    if not lang and interactive:
+        lang = ask(_PROMPT).strip().lower()
+    if lang:
+        _store_lang(lang)
+        print(f"language: {lang} (stored in {config.SETTINGS_PATH})")
+    else:
+        print("language: not set — the multilingual bundled model covers everyone")
+
+    s = config.resolve_embed()   # fresh & live: sees the answer just stored
+    print(f"embedder: {s.provider} / {s.model} (dim {s.dim})\n"
+          "  (a VOYAGE_API_KEY, a running local server, or SESSION_RECALL_EMBED "
+          "override this — see README → Embedding providers)")
+
+    files, size = _transcript_footprint()
+    print(f"history on disk: {files} transcript(s), {size / 1e6:.1f} MB")
+
+    go = args.yes or (interactive and
+                      ask("run the first index now? [Y/n]: ").strip().lower()
+                      not in ("n", "no"))
+    if not go:
+        print("when ready: session-recall index")
+        return 0
+    return index_cmd()

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -1,0 +1,67 @@
+"""`setup` — the onboarding must ask once, store the answer, and never be the
+thing that surprises: no question when not a tty, no index without consent."""
+
+import argparse
+import json
+
+import pytest
+
+from session_recall import config, onboarding
+
+
+@pytest.fixture
+def settings(tmp_path, monkeypatch):
+    path = tmp_path / "settings.json"
+    monkeypatch.setattr(config, "SETTINGS_PATH", path)
+    # keep the footprint scan away from the real machine
+    monkeypatch.setattr(config, "CLAUDE_PROJECTS", tmp_path / "cl")
+    monkeypatch.setattr(config, "CODEX_SESSIONS", tmp_path / "cx")
+    monkeypatch.setattr(config, "CODEX_ARCHIVED_SESSIONS", tmp_path / "cxa")
+    return path
+
+
+def _args(lang=None, yes=False):
+    return argparse.Namespace(lang=lang, yes=yes)
+
+
+def test_explicit_lang_is_stored_and_merged(settings):
+    settings.write_text('{"keep": "me"}')
+    rc = onboarding.run(_args(lang="RU"), index_cmd=lambda: 99, is_tty=False)
+    assert rc == 0, "no tty and no --yes: the index must not run"
+    stored = json.loads(settings.read_text())
+    assert stored == {"keep": "me", "lang": "ru"}
+
+
+def test_interactive_asks_once_and_runs_the_index_on_consent(settings):
+    answers = iter(["zh", "y"])
+    ran = []
+    rc = onboarding.run(_args(), index_cmd=lambda: ran.append(1) or 0,
+                        ask=lambda prompt: next(answers), is_tty=True)
+    assert rc == 0 and ran == [1]
+    assert json.loads(settings.read_text())["lang"] == "zh"
+
+
+def test_interactive_no_declines_the_index(settings):
+    answers = iter(["", "n"])
+    rc = onboarding.run(_args(), index_cmd=lambda: 99,
+                        ask=lambda prompt: next(answers), is_tty=True)
+    assert rc == 0
+    assert not settings.exists(), "empty answer stores nothing — multi by default"
+
+
+def test_yes_is_fully_non_interactive(settings):
+    def never_ask(prompt):
+        raise AssertionError("--yes must not prompt")
+    rc = onboarding.run(_args(lang="en", yes=True), index_cmd=lambda: 7,
+                        ask=never_ask, is_tty=True)
+    assert rc == 7, "--yes runs the index and surfaces its exit code"
+    assert json.loads(settings.read_text())["lang"] == "en"
+
+
+def test_footprint_counts_transcripts(settings, tmp_path):
+    d = tmp_path / "cl" / "proj"
+    d.mkdir(parents=True)
+    (d / "a.jsonl").write_text("x" * 100)
+    (d / "b.jsonl").write_text("y" * 50)
+    files, size = onboarding._transcript_footprint()
+    assert files == 2 and size == 150


### PR DESCRIPTION
The last piece of the language-aware defaults (#42): the place that actually **asks**.

```console
$ session-recall setup
Interaction language — steers the bundled embedding model [en/zh/ru/…, Enter = multilingual]: ru
language: ru (stored in ~/.local/share/session-recall/settings.json)
embedder: builtin / sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2 (dim 384)
history on disk: 1052 transcript(s), 214.3 MB
run the first index now? [Y/n]:
```

- `--lang xx --yes` = fully scripted; not a tty → no questions, no surprise indexing, exit 0 with next steps.
- The index runs as a **child process** on purpose: embed settings resolve at import time, only a fresh process sees the language just stored.
- `settings.json` is read-modify-write — setup owns the `lang` key, everything else survives.
- README install section leads with `setup`; `index` directly still works, every setting has a default.

Live-smoked in an isolated `XDG_DATA_HOME`. Suite 323 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)