### PR TITLE
docs: cross-link the Spanish community translation

### DIFF
--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -2,6 +2,10 @@
 
 # session-recall
 
+*Traducción de la comunidad (gracias, @webbrain-one). Puede ir por detrás del
+[README en inglés](README.md), que es la referencia; versión en ruso:
+[docs/README.ru.md](docs/README.ru.md).*
+
 **Memoria compartida para Claude Code y Codex.** Retoma el trabajo de hace un mes sin tener que reexplicarlo: y Claude puede leer lo que Codex resolvió ayer, porque ambos motores alimentan un mismo índice. No es un archivo de resumen que alguien mantiene a mano: son los turnos reales, incluidas las llamadas a herramientas y el razonamiento, buscables por significado.
 
 ```console

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # session-recall
 
-*Русская версия: [docs/README.ru.md](docs/README.ru.md)*
+*Русская версия: [docs/README.ru.md](docs/README.ru.md) · Español:
+[README.es-ES.md](README.es-ES.md) (community translation)*
 
 **Shared memory for Claude Code, Codex, and Cursor.** Pick up work from a month ago without
 re-explaining it — and Claude can read what Codex worked out yesterday, because both engines


### PR DESCRIPTION
Follow-up to #27 (first external contribution 🎉): a community-translation note on top of README.es-ES.md naming the English README as the reference (it moved a week ahead of the translation), plus language cross-links in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)