### PR TITLE
docs: tools diagram — grep joins the evidence chain, add the outcome node

### DIFF
--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -89,10 +89,12 @@ La interfaz se mantiene deliberadamente pequeña:
 ```mermaid
 flowchart LR
     Q["describe the old problem"] --> S["recall_search"]
-    S --> A["ranked anchor"]
+    X["exact error / symbol / path"] --> G["grep"]
+    S --> A["anchor: session + turn"]
+    G --> A
     A --> E["expand_around"]
-    E --> T["step next / prev"]
-    Q -. exact identifier .-> G["grep"]
+    E <--> T["step next / prev"]
+    E --> V["grounded answer + raw evidence"]
     R["what is current?"] --> RS["recent_sessions"]
 ```
 

--- a/README.md
+++ b/README.md
@@ -82,10 +82,12 @@ The interface stays deliberately small:
 ```mermaid
 flowchart LR
     Q["describe the old problem"] --> S["recall_search"]
-    S --> A["ranked anchor"]
+    X["exact error / symbol / path"] --> G["grep"]
+    S --> A["anchor: session + turn"]
+    G --> A
     A --> E["expand_around"]
-    E --> T["step next / prev"]
-    Q -. exact identifier .-> G["grep"]
+    E <--> T["step next / prev"]
+    E --> V["grounded answer + raw evidence"]
     R["what is current?"] --> RS["recent_sessions"]
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -80,10 +80,12 @@ Session Recall 把这些历史汇成一个本地优先的索引，再通过五�
 ```mermaid
 flowchart LR
     Q["describe the old problem"] --> S["recall_search"]
-    S --> A["ranked anchor"]
+    X["exact error / symbol / path"] --> G["grep"]
+    S --> A["anchor: session + turn"]
+    G --> A
     A --> E["expand_around"]
-    E --> T["step next / prev"]
-    Q -. exact identifier .-> G["grep"]
+    E <--> T["step next / prev"]
+    E --> V["grounded answer + raw evidence"]
     R["what is current?"] --> RS["recent_sessions"]
 ```
 

--- a/docs/README.ru.md
+++ b/docs/README.ru.md
@@ -87,10 +87,12 @@ Session Recall превращает эту историю в единый local-
 ```mermaid
 flowchart LR
     Q["describe the old problem"] --> S["recall_search"]
-    S --> A["ranked anchor"]
+    X["exact error / symbol / path"] --> G["grep"]
+    S --> A["anchor: session + turn"]
+    G --> A
     A --> E["expand_around"]
-    E --> T["step next / prev"]
-    Q -. exact identifier .-> G["grep"]
+    E <--> T["step next / prev"]
+    E --> V["grounded answer + raw evidence"]
     R["what is current?"] --> RS["recent_sessions"]
 ```
 


### PR DESCRIPTION
Fixes two distortions in the five-tools mermaid diagram, in all four language versions:

- **grep was drawn as a dead end.** It returns the same anchors (session + turn) as `recall_search`, so both entry points now converge on one `anchor` node feeding `expand_around`.
- **The chain ended on a tool, not the outcome.** Added the `grounded answer + raw evidence` node; `step` is now shown as the bidirectional cursor it is.

`recent_sessions` intentionally stays a separate lane — it returns sessions and index freshness, not per-turn anchors.

Node labels stay English in all translations (as before), so the four files remain byte-identical in their mermaid blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)